### PR TITLE
Fix ladybird fetch security embedded credentials

### DIFF
--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -85,7 +85,7 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
 
     auto& vm = realm.vm();
 
-    // 1. Assert: request’s mode is "navigate" or processEarlyHintsResponse is null.
+    // 1. Assert: request's mode is "navigate" or processEarlyHintsResponse is null.
     VERIFY(request.mode() == Infrastructure::Request::Mode::Navigate || !algorithms.process_early_hints_response());
 
     // 2. Let taskDestination be null.
@@ -97,12 +97,12 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
     // 4. Populate request from client given request.
     populate_request_from_client(realm, request);
 
-    // 5. If request’s client is non-null, then:
+    // 5. If request's client is non-null, then:
     if (request.client() != nullptr) {
-        // 1. Set taskDestination to request’s client’s global object.
+        // 1. Set taskDestination to request's client's global object.
         task_destination = GC::Ref { request.client()->global_object() };
 
-        // 2. Set crossOriginIsolatedCapability to request’s client’s cross-origin isolated capability.
+        // 2. Set crossOriginIsolatedCapability to request's client's cross-origin isolated capability.
         cross_origin_isolated_capability = request.client()->cross_origin_isolated_capability();
     }
 
@@ -111,7 +111,7 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
         task_destination = HTML::ParallelQueue::create();
 
     // 7. Let timingInfo be a new fetch timing info whose start time and post-redirect start time are the coarsened
-    //    shared current time given crossOriginIsolatedCapability, and render-blocking is set to request’s
+    //    shared current time given crossOriginIsolatedCapability, and render-blocking is set to request's
     //    render-blocking.
     auto timing_info = Infrastructure::FetchTimingInfo::create(vm);
     auto now = HighResolutionTime::coarsened_shared_current_time(cross_origin_isolated_capability == HTML::CanUseCrossOriginIsolatedAPIs::Yes);
@@ -129,54 +129,54 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
     fetch_params->set_task_destination(task_destination);
     fetch_params->set_cross_origin_isolated_capability(cross_origin_isolated_capability);
 
-    // 9. If request’s body is a byte sequence, then set request’s body to request’s body as a body.
+    // 9. If request's body is a byte sequence, then set request's body to request's body as a body.
     if (auto const* buffer = request.body().get_pointer<ByteBuffer>())
         request.set_body(Infrastructure::byte_sequence_as_body(realm, buffer->bytes()));
 
     // 10. If all of the following conditions are true:
     if (
-        // - request’s URL’s scheme is an HTTP(S) scheme
+        // - request's URL's scheme is an HTTP(S) scheme
         Infrastructure::is_http_or_https_scheme(request.url().scheme())
-        // - request’s mode is "same-origin", "cors", or "no-cors"
+        // - request's mode is "same-origin", "cors", or "no-cors"
         && (request.mode() == Infrastructure::Request::Mode::SameOrigin || request.mode() == Infrastructure::Request::Mode::CORS || request.mode() == Infrastructure::Request::Mode::NoCORS)
-        // - request’s client is not null, and request’s client’s global object is a Window object
+        // - request's client is not null, and request's client's global object is a Window object
         && request.client() && is<HTML::Window>(request.client()->global_object())
-        // - request’s method is `GET`
+        // - request's method is `GET`
         && StringView { request.method() }.equals_ignoring_ascii_case("GET"sv)
-        // - request’s unsafe-request flag is not set or request’s header list is empty
+        // - request's unsafe-request flag is not set or request's header list is empty
         && (!request.unsafe_request() || request.header_list()->is_empty())) {
-        // 1. Assert: request’s origin is same origin with request’s client’s origin.
+        // 1. Assert: request's origin is same origin with request's client's origin.
         VERIFY(request.origin().has<URL::Origin>() && request.origin().get<URL::Origin>().is_same_origin(request.client()->origin()));
 
         // 2. Let onPreloadedResponseAvailable be an algorithm that runs the following step given a response
-        //    response: set fetchParams’s preloaded response candidate to response.
+        //    response: set fetchParams's preloaded response candidate to response.
         auto on_preloaded_response_available = GC::create_function(realm.heap(), [fetch_params](GC::Ref<Infrastructure::Response> response) {
             fetch_params->set_preloaded_response_candidate(response);
         });
 
-        // FIXME: 3. Let foundPreloadedResource be the result of invoking consume a preloaded resource for request’s
-        //    window, given request’s URL, request’s destination, request’s mode, request’s credentials mode,
-        //    request’s integrity metadata, and onPreloadedResponseAvailable.
+        // FIXME: 3. Let foundPreloadedResource be the result of invoking consume a preloaded resource for request's
+        //    window, given request's URL, request's destination, request's mode, request's credentials mode,
+        //    request's integrity metadata, and onPreloadedResponseAvailable.
         auto found_preloaded_resource = false;
         (void)on_preloaded_response_available;
 
-        // 4. If foundPreloadedResource is true and fetchParams’s preloaded response candidate is null, then set
-        //    fetchParams’s preloaded response candidate to "pending".
+        // 4. If foundPreloadedResource is true and fetchParams's preloaded response candidate is null, then set
+        //    fetchParams's preloaded response candidate to "pending".
         if (found_preloaded_resource && fetch_params->preloaded_response_candidate().has<Empty>())
             fetch_params->set_preloaded_response_candidate(Infrastructure::FetchParams::PreloadedResponseCandidatePendingTag {});
     }
 
-    // 11. If request’s header list does not contain `Accept`, then:
+    // 11. If request's header list does not contain `Accept`, then:
     if (!request.header_list()->contains("Accept"sv.bytes())) {
         // 1. Let value be `*/*`.
         auto value = "*/*"sv;
 
-        // 2. If request’s initiator is "prefetch", then set value to the document `Accept` header value.
+        // 2. If request's initiator is "prefetch", then set value to the document `Accept` header value.
         if (request.initiator() == Infrastructure::Request::Initiator::Prefetch) {
             value = document_accept_header_value;
         }
 
-        // 3. Otherwise, the user agent should set value to the first matching statement, if any, switching on request’s destination:
+        // 3. Otherwise, the user agent should set value to the first matching statement, if any, switching on request's destination:
         else if (request.destination().has_value()) {
             switch (*request.destination()) {
             // -> "document"
@@ -208,13 +208,13 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
             }
         }
 
-        // 4. Append (`Accept`, value) to request’s header list.
+        // 4. Append (`Accept`, value) to request's header list.
         auto header = Infrastructure::Header::from_string_pair("Accept"sv, value.bytes());
         request.header_list()->append(move(header));
     }
 
-    // 12. If request’s header list does not contain `Accept-Language`, then user agents should append
-    //     (`Accept-Language, an appropriate header value) to request’s header list.
+    // 12. If request's header list does not contain `Accept-Language`, then user agents should append
+    //     (`Accept-Language, an appropriate header value) to request's header list.
     if (!request.header_list()->contains("Accept-Language"sv.bytes())) {
         StringBuilder accept_language;
         accept_language.join(","sv, ResourceLoader::the().preferred_languages());
@@ -223,25 +223,25 @@ WebIDL::ExceptionOr<GC::Ref<Infrastructure::FetchController>> fetch(JS::Realm& r
         request.header_list()->append(move(header));
     }
 
-    // 13. If request’s internal priority is null, then use request’s priority, initiator, destination, and
-    //     render-blocking in an implementation-defined manner to set request’s internal priority to an
+    // 13. If request's internal priority is null, then use request's priority, initiator, destination, and
+    //     render-blocking in an implementation-defined manner to set request's internal priority to an
     //     implementation-defined object.
     // NOTE: The user-agent-defined object could encompass stream weight and dependency for HTTP/2, and equivalent
     //       information used to prioritize dispatch and processing of HTTP/1 fetches.
 
     // 14. If request is a subresource request, then:
     if (request.is_subresource_request()) {
-        // 1. Let record be a new fetch record whose request is request and controller is fetchParams’s controller.
+        // 1. Let record be a new fetch record whose request is request and controller is fetchParams's controller.
         auto record = Infrastructure::FetchRecord::create(vm, request, fetch_params->controller());
 
-        // 2. Append record to request’s client’s fetch group’s fetch records.
+        // 2. Append record to request's client's fetch group's fetch records.
         request.client()->fetch_group().append(record);
     }
 
     // 15. Run main fetch given fetchParams.
     (void)TRY(main_fetch(realm, fetch_params));
 
-    // 16. Return fetchParams’s controller.
+    // 16. Return fetchParams's controller.
     return fetch_params->controller();
 }
 
@@ -250,19 +250,19 @@ void populate_request_from_client(JS::Realm const& realm, Infrastructure::Reques
 {
     auto& heap = realm.heap();
 
-    // 1. If request’s traversable for user prompts is "client":
+    // 1. If request's traversable for user prompts is "client":
     auto const* traversable_for_user_prompts = request.traversable_for_user_prompts().get_pointer<Infrastructure::Request::TraversableForUserPrompts>();
     if (traversable_for_user_prompts && *traversable_for_user_prompts == Infrastructure::Request::TraversableForUserPrompts::Client) {
-        // 1. Set request’s traversable for user prompts to "no-traversable".
+        // 1. Set request's traversable for user prompts to "no-traversable".
         request.set_traversable_for_user_prompts(Infrastructure::Request::TraversableForUserPrompts::NoTraversable);
 
-        // 2. If request’s client is non-null:
+        // 2. If request's client is non-null:
         if (request.client()) {
-            // 1. Let global be request’s client’s global object.
+            // 1. Let global be request's client's global object.
             auto& global = request.client()->global_object();
 
-            // 2. If global is a Window object and global’s navigable is not null, then set request’s traversable for
-            //    user prompts to global’s navigable’s traversable navigable.
+            // 2. If global is a Window object and global's navigable is not null, then set request's traversable for
+            //    user prompts to global's navigable's traversable navigable.
             if (auto const* window = as_if<HTML::Window>(global)) {
                 if (window->navigable())
                     request.set_traversable_for_user_prompts(window->navigable()->traversable_navigable());
@@ -270,24 +270,24 @@ void populate_request_from_client(JS::Realm const& realm, Infrastructure::Reques
         }
     }
 
-    // 2. If request’s origin is "client":
+    // 2. If request's origin is "client":
     auto const* origin = request.origin().get_pointer<Infrastructure::Request::Origin>();
     if (origin && *origin == Infrastructure::Request::Origin::Client) {
-        // 1. Assert: request’s client is non-null.
+        // 1. Assert: request's client is non-null.
         VERIFY(request.client());
 
-        // 2. Set request’s origin to request’s client’s origin.
+        // 2. Set request's origin to request's client's origin.
         request.set_origin(request.client()->origin());
     }
 
-    // 3. If request’s policy container is "client":
+    // 3. If request's policy container is "client":
     auto const* policy_container = request.policy_container().get_pointer<Infrastructure::Request::PolicyContainer>();
     if (policy_container && *policy_container == Infrastructure::Request::PolicyContainer::Client) {
-        // 1. If request’s client is non-null, then set request’s policy container to a clone of request’s client’s
+        // 1. If request's client is non-null, then set request's policy container to a clone of request's client's
         //    policy container.
         if (request.client())
             request.set_policy_container(request.client()->policy_container()->clone(heap));
-        // 2. Otherwise, set request’s policy container to a new policy container.
+        // 2. Otherwise, set request's policy container to a new policy container.
         else
             request.set_policy_container(heap.allocate<HTML::PolicyContainer>(heap));
     }
@@ -300,13 +300,13 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
 
     auto& vm = realm.vm();
 
-    // 1. Let request be fetchParams’s request.
+    // 1. Let request be fetchParams's request.
     auto request = fetch_params.request();
 
     // 2. Let response be null.
     GC::Ptr<Infrastructure::Response> response;
 
-    // 3. If request’s local-URLs-only flag is set and request’s current URL is not local, then set response to a
+    // 3. If request's local-URLs-only flag is set and request's current URL is not local, then set response to a
     //    network error.
     if (request->local_urls_only() && !Infrastructure::is_local_url(request->current_url()))
         response = Infrastructure::Response::network_error(vm, "Request with 'local-URLs-only' flag must have a local URL"_string);
@@ -327,16 +327,16 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
         response = Infrastructure::Response::network_error(vm, "Request was blocked"_string);
     }
 
-    // 8. If request’s referrer policy is the empty string, then set request’s referrer policy to request’s policy
-    //    container’s referrer policy.
+    // 8. If request's referrer policy is the empty string, then set request's referrer policy to request's policy
+    //    container's referrer policy.
     if (request->referrer_policy() == ReferrerPolicy::ReferrerPolicy::EmptyString) {
         VERIFY(request->policy_container().has<GC::Ref<HTML::PolicyContainer>>());
         request->set_referrer_policy(request->policy_container().get<GC::Ref<HTML::PolicyContainer>>()->referrer_policy);
     }
 
-    // 9. If request’s referrer is not "no-referrer", then set request’s referrer to the result of invoking determine
-    //    request’s referrer.
-    // NOTE: As stated in Referrer Policy, user agents can provide the end user with options to override request’s
+    // 9. If request's referrer is not "no-referrer", then set request's referrer to the result of invoking determine
+    //    request's referrer.
+    // NOTE: As stated in Referrer Policy, user agents can provide the end user with options to override request's
     //       referrer to "no-referrer" or have it expose less sensitive information.
     auto const* referrer = request->referrer().get_pointer<Infrastructure::Request::Referrer>();
     if (!referrer || *referrer != Infrastructure::Request::Referrer::NoReferrer) {
@@ -347,13 +347,13 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
             request->set_referrer(Infrastructure::Request::Referrer::NoReferrer);
     }
 
-    // 10. Set request’s current URL’s scheme to "https" if all of the following conditions are true:
+    // 10. Set request's current URL's scheme to "https" if all of the following conditions are true:
     if (
-        // - request’s current URL’s scheme is "http"
+        // - request's current URL's scheme is "http"
         request->current_url().scheme() == "http"sv
-        // - request’s current URL’s host is a domain
+        // - request's current URL's host is a domain
         && request->current_url().host().has_value() && request->current_url().host()->is_domain()
-        // FIXME: - Matching request’s current URL’s host per Known HSTS Host Domain Name Matching results in either a
+        // FIXME: - Matching request's current URL's host per Known HSTS Host Domain Name Matching results in either a
         //          superdomain match with an asserted includeSubDomains directive or a congruent match (with or without an
         //          asserted includeSubDomains directive) [HSTS]; or DNS resolution for the request finds a matching HTTPS RR
         //          per section 9.5 of [SVCB].
@@ -365,28 +365,28 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
         dbgln_if(WEB_FETCH_DEBUG, "Fetch: Running 'main fetch' get_response() function");
         auto const* origin = request->origin().get_pointer<URL::Origin>();
 
-        // -> fetchParams’s preloaded response candidate is not null
+        // -> fetchParams's preloaded response candidate is not null
         if (!fetch_params.preloaded_response_candidate().has<Empty>()) {
-            // 1. Wait until fetchParams’s preloaded response candidate is not "pending".
+            // 1. Wait until fetchParams's preloaded response candidate is not "pending".
             HTML::main_thread_event_loop().spin_until(GC::create_function(vm.heap(), [&] {
                 return !fetch_params.preloaded_response_candidate().has<Infrastructure::FetchParams::PreloadedResponseCandidatePendingTag>();
             }));
 
-            // 2. Assert: fetchParams’s preloaded response candidate is a response.
+            // 2. Assert: fetchParams's preloaded response candidate is a response.
             VERIFY(fetch_params.preloaded_response_candidate().has<GC::Ref<Infrastructure::Response>>());
 
-            // 3. Return fetchParams’s preloaded response candidate.
+            // 3. Return fetchParams's preloaded response candidate.
             return PendingResponse::create(vm, request, fetch_params.preloaded_response_candidate().get<GC::Ref<Infrastructure::Response>>());
         }
 
-        // -> request’s current URL’s origin is same origin with request’s origin, and request’s response tainting is "basic"
-        // -> request’s current URL’s scheme is "data"
-        // -> request’s mode is "navigate" or "websocket"
+        // -> request's current URL's origin is same origin with request's origin, and request's response tainting is "basic"
+        // -> request's current URL's scheme is "data"
+        // -> request's mode is "navigate" or "websocket"
         if (
             (origin && request->current_url().origin().is_same_origin(*origin) && request->response_tainting() == Infrastructure::Request::ResponseTainting::Basic)
             || request->current_url().scheme() == "data"sv
             || (request->mode() == Infrastructure::Request::Mode::Navigate || request->mode() == Infrastructure::Request::Mode::WebSocket)) {
-            // 1. Set request’s response tainting to "basic".
+            // 1. Set request's response tainting to "basic".
             request->set_response_tainting(Infrastructure::Request::ResponseTainting::Basic);
 
             // 2. Return the result of running scheme fetch given fetchParams.
@@ -396,26 +396,26 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
             //       opaque origin. Service workers can only be created from URLs whose scheme is an HTTP(S) scheme.
         }
 
-        // -> request’s mode is "same-origin"
+        // -> request's mode is "same-origin"
         if (request->mode() == Infrastructure::Request::Mode::SameOrigin) {
             // Return a network error.
             return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request with 'same-origin' mode must have same URL and request origin"_string));
         }
 
-        // -> request’s mode is "no-cors"
+        // -> request's mode is "no-cors"
         if (request->mode() == Infrastructure::Request::Mode::NoCORS) {
-            // 1. If request’s redirect mode is not "follow", then return a network error.
+            // 1. If request's redirect mode is not "follow", then return a network error.
             if (request->redirect_mode() != Infrastructure::Request::RedirectMode::Follow)
                 return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request with 'no-cors' mode must have redirect mode set to 'follow'"_string));
 
-            // 2. Set request’s response tainting to "opaque".
+            // 2. Set request's response tainting to "opaque".
             request->set_response_tainting(Infrastructure::Request::ResponseTainting::Opaque);
 
             // 3. Return the result of running scheme fetch given fetchParams.
             return scheme_fetch(realm, fetch_params);
         }
 
-        // -> request’s current URL’s scheme is not an HTTP(S) scheme
+        // -> request's current URL's scheme is not an HTTP(S) scheme
         // AD-HOC: We allow CORS requests for resource:// URLs from opaque origins to enable requesting JS modules from internal pages.
         if (!Infrastructure::is_http_or_https_scheme(request->current_url().scheme())
             && !(origin && origin->is_opaque() && request->current_url().scheme() == "resource"sv)) {
@@ -426,15 +426,15 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
             return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request with 'cors' mode must have URL with HTTP or HTTPS scheme"_string));
         }
 
-        // -> request’s use-CORS-preflight flag is set
-        // -> request’s unsafe-request flag is set and either request’s method is not a CORS-safelisted method or
-        //    CORS-unsafe request-header names with request’s header list is not empty
+        // -> request's use-CORS-preflight flag is set
+        // -> request's unsafe-request flag is set and either request's method is not a CORS-safelisted method or
+        //    CORS-unsafe request-header names with request's header list is not empty
         if (
             request->use_cors_preflight()
             || (request->unsafe_request()
                 && (!Infrastructure::is_cors_safelisted_method(request->method())
                     || !Infrastructure::get_cors_unsafe_header_names(request->header_list()).is_empty()))) {
-            // 1. Set request’s response tainting to "cors".
+            // 1. Set request's response tainting to "cors".
             request->set_response_tainting(Infrastructure::Request::ResponseTainting::CORS);
 
             auto returned_pending_response = PendingResponse::create(vm, request);
@@ -456,7 +456,7 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
         }
 
         // -> Otherwise
-        //     1. Set request’s response tainting to "cors".
+        //     1. Set request's response tainting to "cors".
         request->set_response_tainting(Infrastructure::Request::ResponseTainting::CORS);
 
         //     2. Return the result of running HTTP fetch given fetchParams.
@@ -491,21 +491,21 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
                 response = resolved_response;
             // 14. If response is not a network error and response is not a filtered response, then:
             if (!response->is_network_error() && !is<Infrastructure::FilteredResponse>(*response)) {
-                // 1. If request’s response tainting is "cors", then:
+                // 1. If request's response tainting is "cors", then:
                 if (request->response_tainting() == Infrastructure::Request::ResponseTainting::CORS) {
                     // 1. Let headerNames be the result of extracting header list values given
-                    //    `Access-Control-Expose-Headers` and response’s header list.
+                    //    `Access-Control-Expose-Headers` and response's header list.
                     auto header_names_or_failure = Infrastructure::extract_header_list_values("Access-Control-Expose-Headers"sv.bytes(), response->header_list());
                     auto header_names = header_names_or_failure.has<Vector<ByteBuffer>>() ? header_names_or_failure.get<Vector<ByteBuffer>>() : Vector<ByteBuffer> {};
 
-                    // 2. If request’s credentials mode is not "include" and headerNames contains `*`, then set
-                    //    response’s CORS-exposed header-name list to all unique header names in response’s header
+                    // 2. If request's credentials mode is not "include" and headerNames contains `*`, then set
+                    //    response's CORS-exposed header-name list to all unique header names in response's header
                     //    list.
                     if (request->credentials_mode() != Infrastructure::Request::CredentialsMode::Include && header_names.contains_slow("*"sv.bytes())) {
                         auto unique_header_names = response->header_list()->unique_names();
                         response->set_cors_exposed_header_name_list(move(unique_header_names));
                     }
-                    // 3. Otherwise, if headerNames is not null or failure, then set response’s CORS-exposed
+                    // 3. Otherwise, if headerNames is not null or failure, then set response's CORS-exposed
                     //    header-name list to headerNames.
                     else if (!header_names.is_empty()) {
                         response->set_cors_exposed_header_name_list(move(header_names));
@@ -513,7 +513,7 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
                 }
 
                 // 2. Set response to the following filtered response with response as its internal response, depending
-                //    on request’s response tainting:
+                //    on request's response tainting:
                 response = [&]() -> GC::Ref<Infrastructure::Response> {
                     switch (request->response_tainting()) {
                     // -> "basic"
@@ -534,21 +534,21 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
                 }();
             }
 
-            // 15. Let internalResponse be response, if response is a network error, and response’s internal response
+            // 15. Let internalResponse be response, if response is a network error, and response's internal response
             //     otherwise.
             auto internal_response = response->is_network_error()
                 ? GC::Ref { *response }
                 : static_cast<Infrastructure::FilteredResponse&>(*response).internal_response();
 
-            // 16. If internalResponse’s URL list is empty, then set it to a clone of request’s URL list.
-            // NOTE: A response’s URL list can be empty (for example, when the response represents an about URL).
+            // 16. If internalResponse's URL list is empty, then set it to a clone of request's URL list.
+            // NOTE: A response's URL list can be empty (for example, when the response represents an about URL).
             if (internal_response->url_list().is_empty())
                 internal_response->set_url_list(request->url_list());
 
-            // 17. Set internalResponse’s redirect taint to request’s redirect-taint.
+            // 17. Set internalResponse's redirect taint to request's redirect-taint.
             internal_response->set_redirect_taint(request->redirect_taint());
 
-            // 18. If request’s timing allow failed flag is unset, then set internalResponse’s timing allow passed flag.
+            // 18. If request's timing allow failed flag is unset, then set internalResponse's timing allow passed flag.
             if (!request->timing_allow_failed())
                 internal_response->set_timing_allow_passed(true);
 
@@ -566,8 +566,8 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
                 response = internal_response = Infrastructure::Response::network_error(vm, "Response was blocked"_string);
             }
 
-            // 20. If response’s type is "opaque", internalResponse’s status is 206, internalResponse’s range-requested
-            //     flag is set, and request’s header list does not contain `Range`, then set response and
+            // 20. If response's type is "opaque", internalResponse's status is 206, internalResponse's range-requested
+            //     flag is set, and request's header list does not contain `Range`, then set response and
             //     internalResponse to a network error.
             // NOTE: Traditionally, APIs accept a ranged response even if a range was not requested. This prevents a
             //       partial response from an earlier ranged request being provided to an API that did not make a range
@@ -579,14 +579,14 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
                 response = internal_response = Infrastructure::Response::network_error(vm, "Response has status 206 and 'range-requested' flag set, but request has no 'Range' header"_string);
             }
 
-            // 21. If response is not a network error and either request’s method is `HEAD` or `CONNECT`, or
-            //     internalResponse’s status is a null body status, set internalResponse’s body to null and disregard
+            // 21. If response is not a network error and either request's method is `HEAD` or `CONNECT`, or
+            //     internalResponse's status is a null body status, set internalResponse's body to null and disregard
             //     any enqueuing toward it (if any).
             // NOTE: This standardizes the error handling for servers that violate HTTP.
             if (!response->is_network_error() && (StringView { request->method() }.is_one_of("HEAD"sv, "CONNECT"sv) || Infrastructure::is_null_body_status(internal_response->status())))
                 internal_response->set_body({});
 
-            // 22. If request’s integrity metadata is not the empty string, then:
+            // 22. If request's integrity metadata is not the empty string, then:
             if (!request->integrity_metadata().is_empty()) {
                 // 1. Let processBodyError be this step: run fetch response handover given fetchParams and a network
                 //    error.
@@ -594,7 +594,7 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
                     fetch_response_handover(realm, fetch_params, Infrastructure::Response::network_error(vm, "Response body could not be processed"_string));
                 });
 
-                // 2. If response’s body is null, then run processBodyError and abort these steps.
+                // 2. If response's body is null, then run processBodyError and abort these steps.
                 if (!response->body()) {
                     process_body_error->function()({});
                     return;
@@ -602,20 +602,20 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
 
                 // 3. Let processBody given bytes be these steps:
                 auto process_body = GC::create_function(vm.heap(), [&realm, request, response, &fetch_params, process_body_error](ByteBuffer bytes) {
-                    // 1. If bytes do not match request’s integrity metadata, then run processBodyError and abort these steps.
+                    // 1. If bytes do not match request's integrity metadata, then run processBodyError and abort these steps.
                     if (!TRY_OR_IGNORE(SRI::do_bytes_match_metadata_list(bytes, request->integrity_metadata()))) {
                         process_body_error->function()({});
                         return;
                     }
 
-                    // 2. Set response’s body to bytes as a body.
+                    // 2. Set response's body to bytes as a body.
                     response->set_body(Infrastructure::byte_sequence_as_body(realm, bytes));
 
                     // 3. Run fetch response handover given fetchParams and response.
                     fetch_response_handover(realm, fetch_params, *response);
                 });
 
-                // 4. Fully read response’s body given processBody and processBodyError.
+                // 4. Fully read response's body given processBody and processBodyError.
                 response->body()->fully_read(realm, process_body, process_body_error, fetch_params.task_destination());
             }
             // 23. Otherwise, run fetch response handover given fetchParams and response.
@@ -631,11 +631,11 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> main_fetch(JS::Realm& realm, Infra
 // https://fetch.spec.whatwg.org/#request-determine-the-environment
 static GC::Ptr<HTML::Environment> determine_the_environment(GC::Ref<Infrastructure::Request> request)
 {
-    // 1. If request’s reserved client is non-null, then return request’s reserved client.
+    // 1. If request's reserved client is non-null, then return request's reserved client.
     if (request->reserved_client())
         return request->reserved_client();
 
-    // 2. If request’s client is non-null, then return request’s client.
+    // 2. If request's client is non-null, then return request's client.
     if (request->client())
         return request->client();
 
@@ -650,12 +650,12 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
 
     auto& vm = realm.vm();
 
-    // 1. Let timingInfo be fetchParams’s timing info.
+    // 1. Let timingInfo be fetchParams's timing info.
     auto timing_info = fetch_params.timing_info();
 
-    // 2. If response is not a network error and fetchParams’s request’s client is a secure context, then set
-    //    timingInfo’s server-timing headers to the result of getting, decoding, and splitting `Server-Timing` from
-    //    response’s header list.
+    // 2. If response is not a network error and fetchParams's request's client is a secure context, then set
+    //    timingInfo's server-timing headers to the result of getting, decoding, and splitting `Server-Timing` from
+    //    response's header list.
     //    The user agent may decide to expose `Server-Timing` headers to non-secure contexts requests as well.
     auto client = fetch_params.request()->client();
     if (!response.is_network_error() && client != nullptr && HTML::is_secure_context(*client)) {
@@ -669,30 +669,30 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
         // 1. Let unsafeEndTime be the unsafe shared current time.
         auto unsafe_end_time = HighResolutionTime::unsafe_shared_current_time();
 
-        // 2. If fetchParams’s request’s destination is "document", then set fetchParams’s controller’s full timing
-        //    info to fetchParams’s timing info.
+        // 2. If fetchParams's request's destination is "document", then set fetchParams's controller's full timing
+        //    info to fetchParams's timing info.
         if (fetch_params.request()->destination() == Infrastructure::Request::Destination::Document)
             fetch_params.controller()->set_full_timing_info(fetch_params.timing_info());
 
-        // 3. Set fetchParams’s controller’s report timing steps to the following steps given a global object global:
+        // 3. Set fetchParams's controller's report timing steps to the following steps given a global object global:
         fetch_params.controller()->set_report_timing_steps([&vm, &response, &fetch_params, timing_info, unsafe_end_time](JS::Object& global) mutable {
-            // 1. If fetchParams’s request’s URL’s scheme is not an HTTP(S) scheme, then return.
+            // 1. If fetchParams's request's URL's scheme is not an HTTP(S) scheme, then return.
             if (!Infrastructure::is_http_or_https_scheme(fetch_params.request()->url().scheme()))
                 return;
 
-            // 2. Set timingInfo’s end time to the relative high resolution time given unsafeEndTime and global.
+            // 2. Set timingInfo's end time to the relative high resolution time given unsafeEndTime and global.
             // Spec Issue: Using relative time here is incorrect, as end time is converted to relative time by Resource Timing,
             //             causing it to take a relative time of an already relative time, effectively make it always a negative
             //             value approximately the value of the time origin.
             timing_info->set_end_time(unsafe_end_time);
 
-            // 3. Let cacheState be response’s cache state.
+            // 3. Let cacheState be response's cache state.
             auto cache_state = response.cache_state();
 
-            // 4. Let bodyInfo be response’s body info.
+            // 4. Let bodyInfo be response's body info.
             auto body_info = response.body_info();
 
-            // 5. If response’s timing allow passed flag is not set, then set timingInfo to the result of creating an
+            // 5. If response's timing allow passed flag is not set, then set timingInfo to the result of creating an
             //    opaque timing info for timingInfo, set bodyInfo to a new response body info, and set cacheState to
             //    the empty string.
             // NOTE: This covers the case of response being a network error.
@@ -705,21 +705,21 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
             // 6. Let responseStatus be 0.
             auto response_status = 0;
 
-            // 7. If fetchParams’s request’s mode is not "navigate" or response’s redirect taint is "same-origin":
+            // 7. If fetchParams's request's mode is not "navigate" or response's redirect taint is "same-origin":
             if (fetch_params.request()->mode() != Infrastructure::Request::Mode::Navigate || response.redirect_taint() == Infrastructure::RedirectTaint::SameOrigin) {
-                // 1. Set responseStatus to response’s status.
+                // 1. Set responseStatus to response's status.
                 response_status = response.status();
 
-                // 2. Let mimeType be the result of extracting a MIME type from response’s header list.
+                // 2. Let mimeType be the result of extracting a MIME type from response's header list.
                 auto mime_type = response.header_list()->extract_mime_type();
 
-                // 3. If mimeType is non-null, then set bodyInfo’s content type to the result of minimizing a supported MIME type given mimeType.
+                // 3. If mimeType is non-null, then set bodyInfo's content type to the result of minimizing a supported MIME type given mimeType.
                 if (mime_type.has_value())
                     body_info.content_type = MimeSniff::minimise_a_supported_mime_type(mime_type.value());
             }
 
-            // 8. If fetchParams’s request’s initiator type is not null, then mark resource timing given timingInfo,
-            //    request’s URL, request’s initiator type, global, cacheState, bodyInfo, and responseStatus.
+            // 8. If fetchParams's request's initiator type is not null, then mark resource timing given timingInfo,
+            //    request's URL, request's initiator type, global, cacheState, bodyInfo, and responseStatus.
             if (fetch_params.request()->initiator_type().has_value()) {
                 ResourceTiming::PerformanceResourceTiming::mark_resource_timing(timing_info, fetch_params.request()->url().to_string(), Infrastructure::initiator_type_to_string(fetch_params.request()->initiator_type().value()), global, cache_state, body_info, response_status);
             }
@@ -727,17 +727,17 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
 
         // 4. Let processResponseEndOfBodyTask be the following steps:
         auto process_response_end_of_body_task = GC::create_function(vm.heap(), [&fetch_params, &response] {
-            // 1. Set fetchParams’s request’s done flag.
+            // 1. Set fetchParams's request's done flag.
             fetch_params.request()->set_done(true);
 
-            // 2. If fetchParams’s process response end-of-body is non-null, then run fetchParams’s process response
+            // 2. If fetchParams's process response end-of-body is non-null, then run fetchParams's process response
             //    end-of-body given response.
             if (fetch_params.algorithms()->process_response_end_of_body())
                 (fetch_params.algorithms()->process_response_end_of_body())(response);
 
-            // 3. If fetchParams’s request’s initiator type is non-null and fetchParams’s request’s client’s global
-            //    object is fetchParams’s task destination, then run fetchParams’s controller’s report timing steps
-            //    given fetchParams’s request’s client’s global object.
+            // 3. If fetchParams's request's initiator type is non-null and fetchParams's request's client's global
+            //    object is fetchParams's task destination, then run fetchParams's controller's report timing steps
+            //    given fetchParams's request's client's global object.
             auto client = fetch_params.request()->client();
             auto const* task_destination_global_object = fetch_params.task_destination().get_pointer<GC::Ref<JS::Object>>();
             if (client != nullptr && task_destination_global_object != nullptr) {
@@ -746,22 +746,22 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
             }
         });
 
-        // 5. Queue a fetch task to run processResponseEndOfBodyTask with fetchParams’s task destination.
+        // 5. Queue a fetch task to run processResponseEndOfBodyTask with fetchParams's task destination.
         Infrastructure::queue_fetch_task(fetch_params.controller(), fetch_params.task_destination(), move(process_response_end_of_body_task));
     };
 
-    // 4. If fetchParams’s process response is non-null, then queue a fetch task to run fetchParams’s process response
-    //    given response, with fetchParams’s task destination.
+    // 4. If fetchParams's process response is non-null, then queue a fetch task to run fetchParams's process response
+    //    given response, with fetchParams's task destination.
     if (fetch_params.algorithms()->process_response()) {
         Infrastructure::queue_fetch_task(fetch_params.controller(), fetch_params.task_destination(), GC::create_function(vm.heap(), [&fetch_params, &response]() {
             fetch_params.algorithms()->process_response()(response);
         }));
     }
 
-    // 5. Let internalResponse be response, if response is a network error; otherwise response’s internal response.
+    // 5. Let internalResponse be response, if response is a network error; otherwise response's internal response.
     auto internal_response = response.is_network_error() ? GC::Ref { response } : response.unsafe_response();
 
-    // 6. If internalResponse’s body is null, then run processResponseEndOfBody.
+    // 6. If internalResponse's body is null, then run processResponseEndOfBody.
     if (!internal_response->body()) {
         process_response_end_of_body();
     }
@@ -786,32 +786,32 @@ void fetch_response_handover(JS::Realm& realm, Infrastructure::FetchParams const
         });
         transform_stream->set_up(identity_transform_algorithm, flush_algorithm);
 
-        // 4. Set internalResponse’s body’s stream to the result of internalResponse’s body’s stream piped through transformStream.
+        // 4. Set internalResponse's body's stream to the result of internalResponse's body's stream piped through transformStream.
         internal_response->body()->set_stream(internal_response->body()->stream()->piped_through(transform_stream));
     }
 
-    // 8. If fetchParams’s process response consume body is non-null, then:
+    // 8. If fetchParams's process response consume body is non-null, then:
     if (fetch_params.algorithms()->process_response_consume_body()) {
-        // 1. Let processBody given nullOrBytes be this step: run fetchParams’s process response consume body given
+        // 1. Let processBody given nullOrBytes be this step: run fetchParams's process response consume body given
         //    response and nullOrBytes.
         auto process_body = GC::create_function(vm.heap(), [&fetch_params, &response](ByteBuffer null_or_bytes) {
             (fetch_params.algorithms()->process_response_consume_body())(response, null_or_bytes);
         });
 
-        // 2. Let processBodyError be this step: run fetchParams’s process response consume body given response and
+        // 2. Let processBodyError be this step: run fetchParams's process response consume body given response and
         //    failure.
         auto process_body_error = GC::create_function(vm.heap(), [&fetch_params, &response](JS::Value) {
             (fetch_params.algorithms()->process_response_consume_body())(response, Infrastructure::FetchAlgorithms::ConsumeBodyFailureTag {});
         });
 
         // 3. If internalResponse's body is null, then queue a fetch task to run processBody given null, with
-        //    fetchParams’s task destination.
+        //    fetchParams's task destination.
         if (!internal_response->body()) {
             Infrastructure::queue_fetch_task(fetch_params.controller(), fetch_params.task_destination(), GC::create_function(vm.heap(), [process_body]() {
                 process_body->function()({});
             }));
         }
-        // 4. Otherwise, fully read internalResponse body given processBody, processBodyError, and fetchParams’s task
+        // 4. Otherwise, fully read internalResponse body given processBody, processBodyError, and fetchParams's task
         //    destination.
         else {
             internal_response->body()->fully_read(realm, process_body, process_body_error, fetch_params.task_destination());
@@ -830,13 +830,13 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
     if (fetch_params.is_canceled())
         return PendingResponse::create(vm, fetch_params.request(), Infrastructure::Response::appropriate_network_error(vm, fetch_params));
 
-    // 2. Let request be fetchParams’s request.
+    // 2. Let request be fetchParams's request.
     auto request = fetch_params.request();
 
-    // 3. Switch on request’s current URL’s scheme and run the associated steps:
+    // 3. Switch on request's current URL's scheme and run the associated steps:
     // -> "about"
     if (request->current_url().scheme() == "about"sv) {
-        // If request’s current URL’s path is the string "blank", then return a new response whose status message is
+        // If request's current URL's path is the string "blank", then return a new response whose status message is
         // `OK`, header list is « (`Content-Type`, `text/html;charset=utf-8`) », and body is the empty byte sequence as
         // a body.
         // NOTE: URLs such as "about:config" are handled during navigation and result in a network error in the context
@@ -857,12 +857,12 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
     }
     // -> "blob"
     else if (request->current_url().scheme() == "blob"sv) {
-        // 1. Let blobURLEntry be request’s current URL’s blob URL entry.
+        // 1. Let blobURLEntry be request's current URL's blob URL entry.
         auto const& blob_url_entry = request->current_url().blob_url_entry();
 
-        // 2. If request’s method is not `GET` or blobURLEntry is null, then return a network error. [FILEAPI]
+        // 2. If request's method is not `GET` or blobURLEntry is null, then return a network error. [FILEAPI]
         if (request->method() != "GET"sv.bytes() || !blob_url_entry.has_value()) {
-            // FIXME: Handle "blobURLEntry’s object is not a Blob object". It could be a MediaSource object, but we
+            // FIXME: Handle "blobURLEntry's object is not a Blob object". It could be a MediaSource object, but we
             //        have not yet implemented the Media Source Extensions spec.
             return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request has an invalid 'blob:' URL"_string));
         }
@@ -870,7 +870,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
         // 3. Let requestEnvironment be the result of determining the environment given request.
         auto request_environment = determine_the_environment(request);
 
-        // 4. Let isTopLevelNavigation be true if request’s destination is "document"; otherwise, false.
+        // 4. Let isTopLevelNavigation be true if request's destination is "document"; otherwise, false.
         bool is_top_level_navigation = request->destination() == Infrastructure::Request::Destination::Document;
 
         // 5. If isTopLevelNavigation is false and requestEnvironment is null, then return a network error.
@@ -896,27 +896,27 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
         // 9. Let response be a new response.
         auto response = Infrastructure::Response::create(vm);
 
-        // 10. Let fullLength be blob’s size.
+        // 10. Let fullLength be blob's size.
         auto full_length = blob->size();
 
         // 11. Let serializedFullLength be fullLength, serialized and isomorphic encoded.
         auto serialized_full_length = String::number(full_length);
 
-        // 12. Let type be blob’s type.
+        // 12. Let type be blob's type.
         auto const& type = blob->type();
 
-        // 13. If request’s header list does not contain `Range`:
+        // 13. If request's header list does not contain `Range`:
         if (!request->header_list()->contains("Range"sv.bytes())) {
             // 1. Let bodyWithType be the result of safely extracting blob.
             auto body_with_type = safely_extract_body(realm, blob->raw_bytes());
 
-            // 2. Set response’s status message to `OK`.
+            // 2. Set response's status message to `OK`.
             response->set_status_message(MUST(ByteBuffer::copy("OK"sv.bytes())));
 
-            // 3. Set response’s body to bodyWithType’s body.
+            // 3. Set response's body to bodyWithType's body.
             response->set_body(body_with_type.body);
 
-            // 4. Set response’s header list to « (`Content-Length`, serializedFullLength), (`Content-Type`, type) ».
+            // 4. Set response's header list to « (`Content-Length`, serializedFullLength), (`Content-Type`, type) ».
             auto content_length_header = Infrastructure::Header::from_string_pair("Content-Length"sv, serialized_full_length);
             response->header_list()->append(move(content_length_header));
 
@@ -925,10 +925,10 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
         }
         // 14. Otherwise:
         else {
-            // 1. Set response’s range-requested flag.
+            // 1. Set response's range-requested flag.
             response->set_range_requested(true);
 
-            // 2. Let rangeHeader be the result of getting `Range` from request’s header list.
+            // 2. Let rangeHeader be the result of getting `Range` from request's header list.
             auto const range_header = request->header_list()->get("Range"sv.bytes()).value_or(ByteBuffer {});
 
             // 3. Let rangeValue be the result of parsing a single range header value given rangeHeader and true.
@@ -968,22 +968,22 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
             // 9. Let slicedBodyWithType be the result of safely extracting slicedBlob.
             auto sliced_body_with_type = safely_extract_body(realm, sliced_blob->raw_bytes());
 
-            // 10. Set response’s body to slicedBodyWithType’s body.
+            // 10. Set response's body to slicedBodyWithType's body.
             response->set_body(sliced_body_with_type.body);
 
-            // 11. Let serializedSlicedLength be slicedBlob’s size, serialized and isomorphic encoded.
+            // 11. Let serializedSlicedLength be slicedBlob's size, serialized and isomorphic encoded.
             auto serialized_sliced_length = String::number(sliced_blob->size());
 
             // 12. Let contentRange be the result of invoking build a content range given rangeStart, rangeEnd, and fullLength.
             auto content_range = Infrastructure::build_content_range(*range_start, *range_end, full_length);
 
-            // 13. Set response’s status to 206.
+            // 13. Set response's status to 206.
             response->set_status(206);
 
-            // 14. Set response’s status message to `Partial Content`.
+            // 14. Set response's status message to `Partial Content`.
             response->set_status_message(MUST(ByteBuffer::copy("Partial Content"sv.bytes())));
 
-            // 15. Set response’s header list to «
+            // 15. Set response's header list to «
 
             // (`Content-Length`, serializedSlicedLength),
             auto content_length_header = Infrastructure::Header::from_string_pair("Content-Length"sv, serialized_sliced_length);
@@ -1003,18 +1003,18 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> scheme_fetch(JS::Realm& realm, Inf
     }
     // -> "data"
     else if (request->current_url().scheme() == "data"sv) {
-        // 1. Let dataURLStruct be the result of running the data: URL processor on request’s current URL.
+        // 1. Let dataURLStruct be the result of running the data: URL processor on request's current URL.
         auto data_url_struct = Infrastructure::process_data_url(request->current_url());
 
         // 2. If dataURLStruct is failure, then return a network error.
         if (data_url_struct.is_error())
             return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Failed to process 'data:' URL"_string));
 
-        // 3. Let mimeType be dataURLStruct’s MIME type, serialized.
+        // 3. Let mimeType be dataURLStruct's MIME type, serialized.
         auto const& mime_type = data_url_struct.value().mime_type.serialized();
 
         // 4. Return a new response whose status message is `OK`, header list is « (`Content-Type`, mimeType) », and
-        //    body is dataURLStruct’s body as a body.
+        //    body is dataURLStruct's body as a body.
         auto response = Infrastructure::Response::create(vm);
         response->set_status_message(MUST(ByteBuffer::copy("OK"sv.bytes())));
 
@@ -1055,45 +1055,45 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_fetch(JS::Realm& realm, Infra
 
     auto& vm = realm.vm();
 
-    // 1. Let request be fetchParams’s request.
+    // 1. Let request be fetchParams's request.
     auto request = fetch_params.request();
 
     // 2. Let response and internalResponse be null.
     GC::Ptr<Infrastructure::Response> response;
     GC::Ptr<Infrastructure::Response> internal_response;
 
-    // 3. If request’s service-workers mode is "all", then:
+    // 3. If request's service-workers mode is "all", then:
     if (request->service_workers_mode() == Infrastructure::Request::ServiceWorkersMode::All) {
         // 1. Let requestForServiceWorker be a clone of request.
         auto request_for_service_worker = request->clone(realm);
 
-        // 2. If requestForServiceWorker’s body is non-null, then:
+        // 2. If requestForServiceWorker's body is non-null, then:
         if (!request_for_service_worker->body().has<Empty>()) {
             // FIXME: 1. Let transformStream be a new TransformStream.
             // FIXME: 2. Let transformAlgorithm given chunk be these steps:
             // FIXME: 3. Set up transformStream with transformAlgorithm set to transformAlgorithm.
-            // FIXME: 4. Set requestForServiceWorker’s body’s stream to the result of requestForServiceWorker’s body’s stream
+            // FIXME: 4. Set requestForServiceWorker's body's stream to the result of requestForServiceWorker's body's stream
             //           piped through transformStream.
         }
 
-        // 3. Let serviceWorkerStartTime be the coarsened shared current time given fetchParams’s cross-origin isolated
+        // 3. Let serviceWorkerStartTime be the coarsened shared current time given fetchParams's cross-origin isolated
         //    capability.
         auto service_worker_start_time = HighResolutionTime::coarsened_shared_current_time(fetch_params.cross_origin_isolated_capability() == HTML::CanUseCrossOriginIsolatedAPIs::Yes);
 
-        // FIXME: 4. Set response to the result of invoking handle fetch for requestForServiceWorker, with fetchParams’s
-        //           controller and fetchParams’s cross-origin isolated capability.
+        // FIXME: 4. Set response to the result of invoking handle fetch for requestForServiceWorker, with fetchParams's
+        //           controller and fetchParams's cross-origin isolated capability.
 
         // 5. If response is non-null, then:
         if (response) {
-            // 1. Set fetchParams’s timing info’s final service worker start time to serviceWorkerStartTime.
+            // 1. Set fetchParams's timing info's final service worker start time to serviceWorkerStartTime.
             fetch_params.timing_info()->set_final_service_worker_start_time(service_worker_start_time);
 
-            // 2. If request’s body is non-null, then cancel request’s body with undefined.
+            // 2. If request's body is non-null, then cancel request's body with undefined.
             if (!request->body().has<Empty>()) {
                 // FIXME: Implement cancelling streams
             }
 
-            // 3. Set internalResponse to response, if response is not a filtered response; otherwise to response’s
+            // 3. Set internalResponse to response, if response is not a filtered response; otherwise to response's
             //    internal response.
             internal_response = !is<Infrastructure::FilteredResponse>(*response)
                 ? GC::Ref { *response }
@@ -1101,15 +1101,15 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_fetch(JS::Realm& realm, Infra
 
             // 4. If one of the following is true
             if (
-                // - response’s type is "error"
+                // - response's type is "error"
                 response->type() == Infrastructure::Response::Type::Error
-                // - request’s mode is "same-origin" and response’s type is "cors"
+                // - request's mode is "same-origin" and response's type is "cors"
                 || (request->mode() == Infrastructure::Request::Mode::SameOrigin && response->type() == Infrastructure::Response::Type::CORS)
-                // - request’s mode is not "no-cors" and response’s type is "opaque"
+                // - request's mode is not "no-cors" and response's type is "opaque"
                 || (request->mode() != Infrastructure::Request::Mode::NoCORS && response->type() == Infrastructure::Response::Type::Opaque)
-                // - request’s redirect mode is not "manual" and response’s type is "opaqueredirect"
+                // - request's redirect mode is not "manual" and response's type is "opaqueredirect"
                 || (request->redirect_mode() != Infrastructure::Request::RedirectMode::Manual && response->type() == Infrastructure::Response::Type::OpaqueRedirect)
-                // - request’s redirect mode is not "follow" and response’s URL list has more than one item.
+                // - request's redirect mode is not "follow" and response's URL list has more than one item.
                 || (request->redirect_mode() != Infrastructure::Request::RedirectMode::Follow && response->url_list().size() > 1)) {
                 // then return a network error.
                 return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Invalid request/response state combination"_string));
@@ -1130,11 +1130,11 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_fetch(JS::Realm& realm, Infra
         //       minimize the number of CORS-preflight fetches.
         GC::Ptr<PendingResponse> pending_preflight_response;
         if (make_cors_preflight == MakeCORSPreflight::Yes && (
-                // - There is no method cache entry match for request’s method using request, and either request’s
-                //   method is not a CORS-safelisted method or request’s use-CORS-preflight flag is set.
+                // - There is no method cache entry match for request's method using request, and either request's
+                //   method is not a CORS-safelisted method or request's use-CORS-preflight flag is set.
                 //   FIXME: We currently have no cache, so there will always be no method cache entry.
                 (!Infrastructure::is_cors_safelisted_method(request->method()) || request->use_cors_preflight())
-                // - There is at least one item in the CORS-unsafe request-header names with request’s header list for
+                // - There is at least one item in the CORS-unsafe request-header names with request's header list for
                 //   which there is no header-name cache entry match using request.
                 //   FIXME: We currently have no cache, so there will always be no header-name cache entry.
                 || !Infrastructure::get_cors_unsafe_header_names(request->header_list()).is_empty())) {
@@ -1145,7 +1145,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_fetch(JS::Realm& realm, Infra
         }
 
         auto fetch_main_content = [request = GC::make_root(request), realm = GC::make_root(realm), fetch_params = GC::make_root(fetch_params)]() -> WebIDL::ExceptionOr<GC::Ref<PendingResponse>> {
-            // 2. If request’s redirect mode is "follow", then set request’s service-workers mode to "none".
+            // 2. If request's redirect mode is "follow", then set request's service-workers mode to "none".
             // NOTE: Redirects coming from the network (as opposed to from a service worker) are not to be exposed to a
             //       service worker.
             if (request->redirect_mode() == Infrastructure::Request::RedirectMode::Follow)
@@ -1183,7 +1183,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_fetch(JS::Realm& realm, Infra
         dbgln_if(WEB_FETCH_DEBUG, "Fetch: Running 'HTTP fetch' pending_actual_response load callback");
         if (response_was_null) {
             response = internal_response = resolved_actual_response;
-            // 4. If request’s response tainting is "cors" and a CORS check for request and response returns failure,
+            // 4. If request's response tainting is "cors" and a CORS check for request and response returns failure,
             //    then return a network error.
             // NOTE: As the CORS check is not to be applied to responses whose status is 304 or 407, or responses from
             //       a service worker for that matter, it is applied here.
@@ -1193,19 +1193,19 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_fetch(JS::Realm& realm, Infra
                 return;
             }
 
-            // 5. If the TAO check for request and response returns failure, then set request’s timing allow failed flag.
+            // 5. If the TAO check for request and response returns failure, then set request's timing allow failed flag.
             if (!tao_check(request, *response))
                 request->set_timing_allow_failed(true);
         }
 
-        // 5. If either request’s response tainting or response’s type is "opaque", and the cross-origin resource
-        //    policy check with request’s origin, request’s client, request’s destination, and internalResponse returns
+        // 5. If either request's response tainting or response's type is "opaque", and the cross-origin resource
+        //    policy check with request's origin, request's client, request's destination, and internalResponse returns
         //    blocked, then return a network error.
         // NOTE: The cross-origin resource policy check runs for responses coming from the network and responses coming
-        //       from the service worker. This is different from the CORS check, as request’s client and the service
+        //       from the service worker. This is different from the CORS check, as request's client and the service
         //       worker can have different embedder policies.
         if ((request->response_tainting() == Infrastructure::Request::ResponseTainting::Opaque || response->type() == Infrastructure::Response::Type::Opaque)
-            && false // FIXME: "and the cross-origin resource policy check with request’s origin, request’s client, request’s destination, and actualResponse returns blocked"
+            && false // FIXME: "and the cross-origin resource policy check with request's origin, request's client, request's destination, and actualResponse returns blocked"
         ) {
             returned_pending_response->resolve(Infrastructure::Response::network_error(vm, "Response was blocked by cross-origin resource policy check"_string));
             return;
@@ -1213,13 +1213,13 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_fetch(JS::Realm& realm, Infra
 
         GC::Ptr<PendingResponse> inner_pending_response;
 
-        // 6. If internalResponse’s status is a redirect status:
+        // 6. If internalResponse's status is a redirect status:
         if (Infrastructure::is_redirect_status(internal_response->status())) {
-            // FIXME: 1. If internalResponse’s status is not 303, request’s body is non-null, and the connection uses HTTP/2,
+            // FIXME: 1. If internalResponse's status is not 303, request's body is non-null, and the connection uses HTTP/2,
             //           then user agents may, and are even encouraged to, transmit an RST_STREAM frame.
             // NOTE: 303 is excluded as certain communities ascribe special status to it.
 
-            // 2. Switch on request’s redirect mode:
+            // 2. Switch on request's redirect mode:
             switch (request->redirect_mode()) {
             // -> "error"
             case Infrastructure::Request::RedirectMode::Error:
@@ -1228,7 +1228,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_fetch(JS::Realm& realm, Infra
                 break;
             // -> "manual"
             case Infrastructure::Request::RedirectMode::Manual:
-                // 1. If request’s mode is "navigate", then set fetchParams’s controller’s next manual redirect steps
+                // 1. If request's mode is "navigate", then set fetchParams's controller's next manual redirect steps
                 //    to run HTTP-redirect fetch given fetchParams and response.
                 if (request->mode() == Infrastructure::Request::Mode::Navigate) {
                     fetch_params.controller()->set_next_manual_redirect_steps([&realm, &fetch_params, response] {
@@ -1262,7 +1262,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_fetch(JS::Realm& realm, Infra
     });
 
     // 7. Return response.
-    // NOTE: Typically internalResponse’s body’s stream is still being enqueued to after returning.
+    // NOTE: Typically internalResponse's body's stream is still being enqueued to after returning.
     return returned_pending_response;
 }
 
@@ -1273,16 +1273,16 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> http_redirect_fetch(JS::Realm& rea
 
     auto& vm = realm.vm();
 
-    // 1. Let request be fetchParams’s request.
+    // 1. Let request be fetchParams's request.
     auto request = fetch_params.request();
 
-    // 2. Let internalResponse be response, if response is not a filtered response; otherwise response’s internal
+    // 2. Let internalResponse be response, if response is not a filtered response; otherwise response's internal
     //    response.
     auto internal_response = !is<Infrastructure::FilteredResponse>(response)
         ? GC::Ref { response }
         : static_cast<Infrastructure::FilteredResponse const&>(response).internal_response();
 
-    // 3. Let locationURL be internalResponse’s location URL given request’s current URL’s fragment.
+    // 3. Let locationURL be internalResponse's location URL given request's current URL's fragment.
     auto location_url_or_error = internal_response->location_url(request->current_url().fragment());
 
     // 4. If locationURL is null, then return response.
@@ -1295,19 +1295,19 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> http_redirect_fetch(JS::Realm& rea
 
     auto location_url = location_url_or_error.release_value().release_value();
 
-    // 6. If locationURL’s scheme is not an HTTP(S) scheme, then return a network error.
+    // 6. If locationURL's scheme is not an HTTP(S) scheme, then return a network error.
     if (!Infrastructure::is_http_or_https_scheme(location_url.scheme()))
         return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request redirect URL must have HTTP or HTTPS scheme"_string));
 
-    // 7. If request’s redirect count is 20, then return a network error.
+    // 7. If request's redirect count is 20, then return a network error.
     if (request->redirect_count() == 20)
         return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request has reached maximum redirect count of 20"_string));
 
-    // 8. Increase request’s redirect count by 1.
+    // 8. Increase request's redirect count by 1.
     request->set_redirect_count(request->redirect_count() + 1);
 
-    // 9. If request’s mode is "cors", locationURL includes credentials, and request’s origin is not same origin with
-    //    locationURL’s origin, then return a network error.
+    // 9. If request's mode is "cors", locationURL includes credentials, and request's origin is not same origin with
+    //    locationURL's origin, then return a network error.
     if (request->mode() == Infrastructure::Request::Mode::CORS
         && location_url.includes_credentials()
         && request->origin().has<URL::Origin>()
@@ -1315,12 +1315,12 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> http_redirect_fetch(JS::Realm& rea
         return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request with 'cors' mode and different URL and request origin must not include credentials in redirect URL"_string));
     }
 
-    // 10. If request’s response tainting is "cors" and locationURL includes credentials, then return a network error.
+    // 10. If request's response tainting is "cors" and locationURL includes credentials, then return a network error.
     // NOTE: This catches a cross-origin resource redirecting to a same-origin URL.
     if (request->response_tainting() == Infrastructure::Request::ResponseTainting::CORS && location_url.includes_credentials())
         return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request with 'cors' response tainting must not include credentials in redirect URL"_string));
 
-    // 11. If internalResponse’s status is not 303, request’s body is non-null, and request’s body’s source is null, then
+    // 11. If internalResponse's status is not 303, request's body is non-null, and request's body's source is null, then
     //     return a network error.
     if (internal_response->status() != 303
         && !request->body().has<Empty>()
@@ -1330,13 +1330,13 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> http_redirect_fetch(JS::Realm& rea
 
     // 12. If one of the following is true
     if (
-        // - internalResponse’s status is 301 or 302 and request’s method is `POST`
+        // - internalResponse's status is 301 or 302 and request's method is `POST`
         ((internal_response->status() == 301 || internal_response->status() == 302) && request->method() == "POST"sv.bytes())
-        // - internalResponse’s status is 303 and request’s method is not `GET` or `HEAD`
+        // - internalResponse's status is 303 and request's method is not `GET` or `HEAD`
         || (internal_response->status() == 303 && !(request->method() == "GET"sv.bytes() || request->method() == "HEAD"sv.bytes()))
         // then:
     ) {
-        // 1. Set request’s method to `GET` and request’s body to null.
+        // 1. Set request's method to `GET` and request's body to null.
         request->set_method(MUST(ByteBuffer::copy("GET"sv.bytes())));
         request->set_body({});
 
@@ -1346,13 +1346,13 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> http_redirect_fetch(JS::Realm& rea
             "Content-Location"sv,
             "Content-Type"sv
         };
-        // 2. For each headerName of request-body-header name, delete headerName from request’s header list.
+        // 2. For each headerName of request-body-header name, delete headerName from request's header list.
         for (auto header_name : request_body_header_names.span())
             request->header_list()->delete_(header_name.bytes());
     }
 
-    // 13. If request’s current URL’s origin is not same origin with locationURL’s origin, then for each headerName of
-    //     CORS non-wildcard request-header name, delete headerName from request’s header list.
+    // 13. If request's current URL's origin is not same origin with locationURL's origin, then for each headerName of
+    //     CORS non-wildcard request-header name, delete headerName from request's header list.
     // NOTE: I.e., the moment another origin is seen after the initial request, the `Authorization` header is removed.
     if (!request->current_url().origin().is_same_origin(location_url.origin())) {
         static constexpr Array cors_non_wildcard_request_header_names {
@@ -1362,9 +1362,9 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> http_redirect_fetch(JS::Realm& rea
             request->header_list()->delete_(header_name.bytes());
     }
 
-    // 14. If request’s body is non-null, then set request’s body to the body of the result of safely extracting
-    //     request’s body’s source.
-    // NOTE: request’s body’s source’s nullity has already been checked.
+    // 14. If request's body is non-null, then set request's body to the body of the result of safely extracting
+    //     request's body's source.
+    // NOTE: request's body's source's nullity has already been checked.
     if (!request->body().has<Empty>()) {
         auto const& source = request->body().get<GC::Ref<Infrastructure::Body>>()->source();
         // NOTE: BodyInitOrReadableBytes is a superset of Body::SourceType
@@ -1375,32 +1375,32 @@ WebIDL::ExceptionOr<GC::Ptr<PendingResponse>> http_redirect_fetch(JS::Realm& rea
         request->set_body(body);
     }
 
-    // 15. Let timingInfo be fetchParams’s timing info.
+    // 15. Let timingInfo be fetchParams's timing info.
     auto timing_info = fetch_params.timing_info();
 
-    // 16. Set timingInfo’s redirect end time and post-redirect start time to the coarsened shared current time given
-    //     fetchParams’s cross-origin isolated capability.
+    // 16. Set timingInfo's redirect end time and post-redirect start time to the coarsened shared current time given
+    //     fetchParams's cross-origin isolated capability.
     auto now = HighResolutionTime::coarsened_shared_current_time(fetch_params.cross_origin_isolated_capability() == HTML::CanUseCrossOriginIsolatedAPIs::Yes);
     timing_info->set_redirect_end_time(now);
     timing_info->set_post_redirect_start_time(now);
 
-    // 17. If timingInfo’s redirect start time is 0, then set timingInfo’s redirect start time to timingInfo’s start
+    // 17. If timingInfo's redirect start time is 0, then set timingInfo's redirect start time to timingInfo's start
     //     time.
     if (timing_info->redirect_start_time() == 0)
         timing_info->set_redirect_start_time(timing_info->start_time());
 
-    // 18. Append locationURL to request’s URL list.
+    // 18. Append locationURL to request's URL list.
     request->url_list().append(location_url);
 
-    // 19. Invoke set request’s referrer policy on redirect on request and internalResponse.
+    // 19. Invoke set request's referrer policy on redirect on request and internalResponse.
     ReferrerPolicy::set_request_referrer_policy_on_redirect(request, internal_response);
 
     // 20. Let recursive be true.
     auto recursive = Recursive::Yes;
 
-    // 21. If request’s redirect mode is "manual", then:
+    // 21. If request's redirect mode is "manual", then:
     if (request->redirect_mode() == Infrastructure::Request::RedirectMode::Manual) {
-        // 1. Assert: request’s mode is "navigate".
+        // 1. Assert: request's mode is "navigate".
         VERIFY(request->mode() == Infrastructure::Request::Mode::Navigate);
 
         // 2. Set recursive to false.
@@ -1694,7 +1694,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
 
     auto& vm = realm.vm();
 
-    // 1. Let request be fetchParams’s request.
+    // 1. Let request be fetchParams's request.
     auto request = fetch_params.request();
 
     // 2. Let httpFetchParams be null.
@@ -1729,7 +1729,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                 aborted = true;
         };
 
-        // 1. If request’s traversable for user prompts is "no-traversable" and request’s redirect mode is "error",
+        // 1. If request's traversable for user prompts is "no-traversable" and request's redirect mode is "error",
         //    then set httpFetchParams to fetchParams and httpRequest to request.
         if (request->traversable_for_user_prompts().has<Infrastructure::Request::TraversableForUserPrompts>()
             && request->traversable_for_user_prompts().get<Infrastructure::Request::TraversableForUserPrompts>() == Infrastructure::Request::TraversableForUserPrompts::NoTraversable
@@ -1740,13 +1740,13 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
         // 2. Otherwise:
         else {
             // 1. Set httpRequest to a clone of request.
-            // NOTE: Implementations are encouraged to avoid teeing request’s body’s stream when request’s body’s
-            //       source is null as only a single body is needed in that case. E.g., when request’s body’s source
+            // NOTE: Implementations are encouraged to avoid teeing request's body's stream when request's body's
+            //       source is null as only a single body is needed in that case. E.g., when request's body's source
             //       is null, redirects and authentication will end up failing the fetch.
             http_request = request->clone(realm);
 
             // 2. Set httpFetchParams to a copy of fetchParams.
-            // 3. Set httpFetchParams’s request to httpRequest.
+            // 3. Set httpFetchParams's request to httpRequest.
             auto new_http_fetch_params = Infrastructure::FetchParams::create(vm, *http_request, fetch_params.timing_info());
             new_http_fetch_params->set_algorithms(fetch_params.algorithms());
             new_http_fetch_params->set_task_destination(fetch_params.task_destination());
@@ -1757,9 +1757,9 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
 
         // 3. Let includeCredentials be true if one of
         if (
-            // - request’s credentials mode is "include"
+            // - request's credentials mode is "include"
             request->credentials_mode() == Infrastructure::Request::CredentialsMode::Include
-            // - request’s credentials mode is "same-origin" and request’s response tainting is "basic"
+            // - request's credentials mode is "same-origin" and request's response tainting is "basic"
             || (request->credentials_mode() == Infrastructure::Request::CredentialsMode::SameOrigin
                 && request->response_tainting() == Infrastructure::Request::ResponseTainting::Basic)
             // is true; otherwise false.
@@ -1774,7 +1774,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
         if (!request->cross_origin_embedder_policy_allows_credentials())
             include_credentials = IncludeCredentials::No;
 
-        // 5. Let contentLength be httpRequest’s body’s length, if httpRequest’s body is non-null; otherwise null.
+        // 5. Let contentLength be httpRequest's body's length, if httpRequest's body is non-null; otherwise null.
         auto content_length = http_request->body().has<GC::Ref<Infrastructure::Body>>()
             ? http_request->body().get<GC::Ref<Infrastructure::Body>>()->length()
             : Optional<u64> {};
@@ -1782,7 +1782,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
         // 6. Let contentLengthHeaderValue be null.
         auto content_length_header_value = Optional<ByteBuffer> {};
 
-        // 7. If httpRequest’s body is null and httpRequest’s method is `POST` or `PUT`, then set
+        // 7. If httpRequest's body is null and httpRequest's method is `POST` or `PUT`, then set
         //    contentLengthHeaderValue to `0`.
         if (http_request->body().has<Empty>() && StringView { http_request->method() }.is_one_of("POST"sv, "PUT"sv))
             content_length_header_value = MUST(ByteBuffer::copy("0"sv.bytes()));
@@ -1793,7 +1793,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             content_length_header_value = MUST(ByteBuffer::copy(String::number(*content_length).bytes()));
 
         // 9. If contentLengthHeaderValue is non-null, then append (`Content-Length`, contentLengthHeaderValue) to
-        //    httpRequest’s header list.
+        //    httpRequest's header list.
         if (content_length_header_value.has_value()) {
             auto header = Infrastructure::Header {
                 .name = MUST(ByteBuffer::copy("Content-Length"sv.bytes())),
@@ -1802,15 +1802,15 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             http_request->header_list()->append(move(header));
         }
 
-        // 10. If contentLength is non-null and httpRequest’s keepalive is true, then:
+        // 10. If contentLength is non-null and httpRequest's keepalive is true, then:
         if (content_length.has_value() && http_request->keepalive()) {
             // 1. Let inflightKeepaliveBytes be 0.
             u64 inflight_keep_alive_bytes = 0;
 
-            // 2. Let group be httpRequest’s client’s fetch group.
+            // 2. Let group be httpRequest's client's fetch group.
             auto& group = http_request->client()->fetch_group();
 
-            // 3. Let inflightRecords be the set of fetch records in group whose request’s keepalive is true and done flag is unset.
+            // 3. Let inflightRecords be the set of fetch records in group whose request's keepalive is true and done flag is unset.
             GC::RootVector<GC::Ref<Infrastructure::FetchRecord>> in_flight_records(vm.heap());
             for (auto& fetch_record : group) {
                 if (fetch_record.request()->keepalive() && !fetch_record.request()->done())
@@ -1819,10 +1819,10 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
 
             // 4. For each fetchRecord of inflightRecords:
             for (auto const& fetch_record : in_flight_records) {
-                // 1. Let inflightRequest be fetchRecord’s request.
+                // 1. Let inflightRequest be fetchRecord's request.
                 auto const& in_flight_request = fetch_record->request();
 
-                // 2. Increment inflightKeepaliveBytes by inflightRequest’s body’s length.
+                // 2. Increment inflightKeepaliveBytes by inflightRequest's body's length.
                 inflight_keep_alive_bytes += in_flight_request->body().visit(
                     [](Empty) -> u64 { return 0; },
                     [](ByteBuffer const& buffer) -> u64 { return buffer.size(); },
@@ -1839,13 +1839,13 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             //       and contain a body, have a bounded size and are not allowed to stay alive indefinitely.
         }
 
-        // 11. If httpRequest’s referrer is a URL, then:
+        // 11. If httpRequest's referrer is a URL, then:
         if (http_request->referrer().has<URL::URL>()) {
-            // 1. Let referrerValue be httpRequest’s referrer, serialized and isomorphic encoded.
+            // 1. Let referrerValue be httpRequest's referrer, serialized and isomorphic encoded.
             auto referrer_string = http_request->referrer().get<URL::URL>().serialize();
             auto referrer_value = TRY_OR_THROW_OOM(vm, ByteBuffer::copy(referrer_string.bytes()));
 
-            // 2. Append (`Referer`, referrerValue) to httpRequest’s header list.
+            // 2. Append (`Referer`, referrerValue) to httpRequest's header list.
             auto header = Infrastructure::Header {
                 .name = MUST(ByteBuffer::copy("Referer"sv.bytes())),
                 .value = move(referrer_value),
@@ -1859,11 +1859,11 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
         // 13. Append the Fetch metadata headers for httpRequest.
         append_fetch_metadata_headers_for_request(*http_request);
 
-        // 14. FIXME If httpRequest’s initiator is "prefetch", then set a structured field value
-        //     given (`Sec-Purpose`, the token prefetch) in httpRequest’s header list.
+        // 14. FIXME If httpRequest's initiator is "prefetch", then set a structured field value
+        //     given (`Sec-Purpose`, the token prefetch) in httpRequest's header list.
 
-        // 15. If httpRequest’s header list does not contain `User-Agent`, then user agents should append
-        //     (`User-Agent`, default `User-Agent` value) to httpRequest’s header list.
+        // 15. If httpRequest's header list does not contain `User-Agent`, then user agents should append
+        //     (`User-Agent`, default `User-Agent` value) to httpRequest's header list.
         if (!http_request->header_list()->contains("User-Agent"sv.bytes())) {
             auto header = Infrastructure::Header {
                 .name = MUST(ByteBuffer::copy("User-Agent"sv.bytes())),
@@ -1872,8 +1872,8 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             http_request->header_list()->append(move(header));
         }
 
-        // 16. If httpRequest’s cache mode is "default" and httpRequest’s header list contains `If-Modified-Since`,
-        //     `If-None-Match`, `If-Unmodified-Since`, `If-Match`, or `If-Range`, then set httpRequest’s cache mode to
+        // 16. If httpRequest's cache mode is "default" and httpRequest's header list contains `If-Modified-Since`,
+        //     `If-None-Match`, `If-Unmodified-Since`, `If-Match`, or `If-Range`, then set httpRequest's cache mode to
         //     "no-store".
         if (http_request->cache_mode() == Infrastructure::Request::CacheMode::Default
             && (http_request->header_list()->contains("If-Modified-Since"sv.bytes())
@@ -1884,9 +1884,9 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             http_request->set_cache_mode(Infrastructure::Request::CacheMode::NoStore);
         }
 
-        // 17. If httpRequest’s cache mode is "no-cache", httpRequest’s prevent no-cache cache-control header
-        //     modification flag is unset, and httpRequest’s header list does not contain `Cache-Control`, then append
-        //     (`Cache-Control`, `max-age=0`) to httpRequest’s header list.
+        // 17. If httpRequest's cache mode is "no-cache", httpRequest's prevent no-cache cache-control header
+        //     modification flag is unset, and httpRequest's header list does not contain `Cache-Control`, then append
+        //     (`Cache-Control`, `max-age=0`) to httpRequest's header list.
         if (http_request->cache_mode() == Infrastructure::Request::CacheMode::NoCache
             && !http_request->prevent_no_cache_cache_control_header_modification()
             && !http_request->header_list()->contains("Cache-Control"sv.bytes())) {
@@ -1894,26 +1894,26 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             http_request->header_list()->append(move(header));
         }
 
-        // 18. If httpRequest’s cache mode is "no-store" or "reload", then:
+        // 18. If httpRequest's cache mode is "no-store" or "reload", then:
         if (http_request->cache_mode() == Infrastructure::Request::CacheMode::NoStore
             || http_request->cache_mode() == Infrastructure::Request::CacheMode::Reload) {
-            // 1. If httpRequest’s header list does not contain `Pragma`, then append (`Pragma`, `no-cache`) to
-            //    httpRequest’s header list.
+            // 1. If httpRequest's header list does not contain `Pragma`, then append (`Pragma`, `no-cache`) to
+            //    httpRequest's header list.
             if (!http_request->header_list()->contains("Pragma"sv.bytes())) {
                 auto header = Infrastructure::Header::from_string_pair("Pragma"sv, "no-cache"sv);
                 http_request->header_list()->append(move(header));
             }
 
-            // 2. If httpRequest’s header list does not contain `Cache-Control`, then append
-            //    (`Cache-Control`, `no-cache`) to httpRequest’s header list.
+            // 2. If httpRequest's header list does not contain `Cache-Control`, then append
+            //    (`Cache-Control`, `no-cache`) to httpRequest's header list.
             if (!http_request->header_list()->contains("Cache-Control"sv.bytes())) {
                 auto header = Infrastructure::Header::from_string_pair("Cache-Control"sv, "no-cache"sv);
                 http_request->header_list()->append(move(header));
             }
         }
 
-        // 19. If httpRequest’s header list contains `Range`, then append (`Accept-Encoding`, `identity`) to
-        //     httpRequest’s header list.
+        // 19. If httpRequest's header list contains `Range`, then append (`Accept-Encoding`, `identity`) to
+        //     httpRequest's header list.
         // NOTE: This avoids a failure when handling content codings with a part of an encoded response.
         //       Additionally, many servers mistakenly ignore `Range` headers if a non-identity encoding is accepted.
         if (http_request->header_list()->contains("Range"sv.bytes())) {
@@ -1921,8 +1921,8 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             http_request->header_list()->append(move(header));
         }
 
-        // 20. Modify httpRequest’s header list per HTTP. Do not append a given header if httpRequest’s header list
-        //     contains that header’s name.
+        // 20. Modify httpRequest's header list per HTTP. Do not append a given header if httpRequest's header list
+        //     contains that header's name.
         // NOTE: It would be great if we could make this more normative somehow. At this point headers such as
         //       `Accept-Encoding`, `Connection`, `DNT`, and `Host`, are to be appended if necessary.
         //     `Accept`, `Accept-Charset`, and `Accept-Language` must not be included at this point.
@@ -1940,7 +1940,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             //    then:
             if (true) {
                 // 1. Let cookies be the result of running the "cookie-string" algorithm (see section 5.4 of [COOKIES])
-                //    with the user agent’s cookie store and httpRequest’s current URL.
+                //    with the user agent's cookie store and httpRequest's current URL.
                 auto cookies = ([&] {
                     // FIXME: Getting to the page client reliably is way too complicated, and going via the document won't work in workers.
                     auto document = Bindings::principal_host_defined_environment_settings_object(HTML::principal_realm(realm)).responsible_document();
@@ -1949,27 +1949,27 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                     return document->page().client().page_did_request_cookie(http_request->current_url(), Cookie::Source::Http);
                 })();
 
-                // 2. If cookies is not the empty string, then append (`Cookie`, cookies) to httpRequest’s header list.
+                // 2. If cookies is not the empty string, then append (`Cookie`, cookies) to httpRequest's header list.
                 if (!cookies.is_empty()) {
                     auto header = Infrastructure::Header::from_string_pair("Cookie"sv, cookies);
                     http_request->header_list()->append(move(header));
                 }
             }
 
-            // 2. If httpRequest’s header list does not contain `Authorization`, then:
+            // 2. If httpRequest's header list does not contain `Authorization`, then:
             if (!http_request->header_list()->contains("Authorization"sv.bytes())) {
                 // 1. Let authorizationValue be null.
                 auto authorization_value = Optional<String> {};
 
-                // 2. If there’s an authentication entry for httpRequest and either httpRequest’s use-URL-credentials
-                //    flag is unset or httpRequest’s current URL does not include credentials, then set
+                // 2. If there's an authentication entry for httpRequest and either httpRequest's use-URL-credentials
+                //    flag is unset or httpRequest's current URL does not include credentials, then set
                 //    authorizationValue to authentication entry.
-                if (false // FIXME: "If there’s an authentication entry for httpRequest"
+                if (false // FIXME: "If there's an authentication entry for httpRequest"
                     && (!http_request->use_url_credentials() || !http_request->current_url().includes_credentials())) {
                     // FIXME: "set authorizationValue to authentication entry."
                 }
-                // 3. Otherwise, if httpRequest’s current URL does include credentials and isAuthenticationFetch is
-                //    true, set authorizationValue to httpRequest’s current URL, converted to an `Authorization` value.
+                // 3. Otherwise, if httpRequest's current URL does include credentials and isAuthenticationFetch is
+                //    true, set authorizationValue to httpRequest's current URL, converted to an `Authorization` value.
                 else if (http_request->current_url().includes_credentials() && is_authentication_fetch == IsAuthenticationFetch::Yes) {
                     auto const& url = http_request->current_url();
                     auto payload = MUST(String::formatted("{}:{}", URL::percent_decode(url.username()), URL::percent_decode(url.password())));
@@ -1977,7 +1977,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                 }
 
                 // 4. If authorizationValue is non-null, then append (`Authorization`, authorizationValue) to
-                //    httpRequest’s header list.
+                //    httpRequest's header list.
                 if (authorization_value.has_value()) {
                     auto header = Infrastructure::Header::from_string_pair("Authorization"sv, *authorization_value);
                     http_request->header_list()->append(move(header));
@@ -1985,17 +1985,17 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             }
         }
 
-        // FIXME: 22. If there’s a proxy-authentication entry, use it as appropriate.
-        // NOTE: This intentionally does not depend on httpRequest’s credentials mode.
+        // FIXME: 22. If there's a proxy-authentication entry, use it as appropriate.
+        // NOTE: This intentionally does not depend on httpRequest's credentials mode.
 
         // 23. Set httpCache to the result of determining the HTTP cache partition, given httpRequest.
         http_cache = determine_the_http_cache_partition(*http_request);
 
-        // 24. If httpCache is null, then set httpRequest’s cache mode to "no-store".
+        // 24. If httpCache is null, then set httpRequest's cache mode to "no-store".
         if (!http_cache)
             http_request->set_cache_mode(Infrastructure::Request::CacheMode::NoStore);
 
-        // 25. If httpRequest’s cache mode is neither "no-store" nor "reload", then:
+        // 25. If httpRequest's cache mode is neither "no-store" nor "reload", then:
         if (http_request->cache_mode() != Infrastructure::Request::CacheMode::NoStore
             && http_request->cache_mode() != Infrastructure::Request::CacheMode::Reload) {
             // 1. Set storedResponse to the result of selecting a response from the httpCache, possibly needing
@@ -2006,7 +2006,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             // 2. If storedResponse is non-null, then:
             if (stored_response) {
                 // 1. If cache mode is "default", storedResponse is a stale-while-revalidate response,
-                //    and httpRequest’s client is non-null, then:
+                //    and httpRequest's client is non-null, then:
                 if (http_request->cache_mode() == Infrastructure::Request::CacheMode::Default
                     && stored_response->is_stale_while_revalidate()
                     && http_request->client() != nullptr) {
@@ -2014,19 +2014,19 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                     // 1. Set response to storedResponse.
                     response = stored_response;
 
-                    // 2. Set response’s cache state to "local".
+                    // 2. Set response's cache state to "local".
                     response->set_cache_state(Infrastructure::Response::CacheState::Local);
 
                     // 3. Let revalidateRequest be a clone of request.
                     auto revalidate_request = request->clone(realm);
 
-                    // 4. Set revalidateRequest’s cache mode set to "no-cache".
+                    // 4. Set revalidateRequest's cache mode set to "no-cache".
                     revalidate_request->set_cache_mode(Infrastructure::Request::CacheMode::NoCache);
 
-                    // 5. Set revalidateRequest’s prevent no-cache cache-control header modification flag.
+                    // 5. Set revalidateRequest's prevent no-cache cache-control header modification flag.
                     revalidate_request->set_prevent_no_cache_cache_control_header_modification(true);
 
-                    // 6. Set revalidateRequest’s service-workers mode set to "none".
+                    // 6. Set revalidateRequest's service-workers mode set to "none".
                     revalidate_request->set_service_workers_mode(Infrastructure::Request::ServiceWorkersMode::None);
 
                     // 7. In parallel, run main fetch given a new fetch params whose request is revalidateRequest.
@@ -2040,22 +2040,22 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                     if (stored_response->is_stale())
                         revalidating_flag->set_value(true);
 
-                    // 2. If the revalidatingFlag is set and httpRequest’s cache mode is neither "force-cache" nor "only-if-cached", then:
+                    // 2. If the revalidatingFlag is set and httpRequest's cache mode is neither "force-cache" nor "only-if-cached", then:
                     if (revalidating_flag->value()
                         && http_request->cache_mode() != Infrastructure::Request::CacheMode::ForceCache
                         && http_request->cache_mode() != Infrastructure::Request::CacheMode::OnlyIfCached) {
 
-                        // 1. If storedResponse’s header list contains `ETag`, then append (`If-None-Match`, `ETag`'s value) to httpRequest’s header list.
+                        // 1. If storedResponse's header list contains `ETag`, then append (`If-None-Match`, `ETag`'s value) to httpRequest's header list.
                         if (auto etag = stored_response->header_list()->get("ETag"sv.bytes()); etag.has_value()) {
                             http_request->header_list()->append(Infrastructure::Header::from_string_pair("If-None-Match"sv, *etag));
                         }
 
-                        // 2. If storedResponse’s header list contains `Last-Modified`, then append (`If-Modified-Since`, `Last-Modified`'s value) to httpRequest’s header list.
+                        // 2. If storedResponse's header list contains `Last-Modified`, then append (`If-Modified-Since`, `Last-Modified`'s value) to httpRequest's header list.
                         if (auto last_modified = stored_response->header_list()->get("Last-Modified"sv.bytes()); last_modified.has_value()) {
                             http_request->header_list()->append(Infrastructure::Header::from_string_pair("If-Modified-Since"sv, *last_modified));
                         }
                     }
-                    // 3. Otherwise, set response to storedResponse and set response’s cache state to "local".
+                    // 3. Otherwise, set response to storedResponse and set response's cache state to "local".
                     else {
                         response = stored_response;
                         response->set_cache_state(Infrastructure::Response::CacheState::Local);
@@ -2073,7 +2073,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
 
     // 10. If response is null, then:
     if (!response) {
-        // 1. If httpRequest’s cache mode is "only-if-cached", then return a network error.
+        // 1. If httpRequest's cache mode is "only-if-cached", then return a network error.
         if (http_request->cache_mode() == Infrastructure::Request::CacheMode::OnlyIfCached)
             return PendingResponse::create(vm, request, Infrastructure::Response::network_error(vm, "Request with 'only-if-cached' cache mode doesn't have a cached response"_string));
 
@@ -2094,7 +2094,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             // NOTE: TRACE is omitted as it is a forbidden method in Fetch.
             auto method_is_unsafe = !(StringView { http_request->method() }.is_one_of("GET"sv, "HEAD"sv, "OPTIONS"sv));
 
-            // 3. If httpRequest’s method is unsafe and forwardResponse’s status is in the range 200 to 399, inclusive,
+            // 3. If httpRequest's method is unsafe and forwardResponse's status is in the range 200 to 399, inclusive,
             //    invalidate appropriate stored responses in httpCache, as per the "Invalidation" chapter of HTTP
             //    Caching, and set storedResponse to null.
             if (method_is_unsafe && forward_response->status() >= 200 && forward_response->status() <= 399) {
@@ -2102,10 +2102,10 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                 stored_response = nullptr;
             }
 
-            // 4. If the revalidatingFlag is set and forwardResponse’s status is 304, then:
+            // 4. If the revalidatingFlag is set and forwardResponse's status is 304, then:
             if (revalidating_flag->value() && forward_response->status() == 304) {
                 dbgln("\033[34;1mHTTP CACHE REVALIDATE (304)\033[0m {}", http_request->current_url());
-                // 1. Update storedResponse’s header list using forwardResponse’s header list, as per the "Freshening
+                // 1. Update storedResponse's header list using forwardResponse's header list, as per the "Freshening
                 //    Stored Responses upon Validation" chapter of HTTP Caching.
                 // NOTE: This updates the stored response in cache as well.
                 http_cache->freshen_stored_responses_upon_validation(*forward_response, initial_set_of_stored_responses);
@@ -2113,7 +2113,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                 // 2. Set response to storedResponse.
                 response = stored_response;
 
-                // 3. Set response’s cache state to "validated".
+                // 3. Set response's cache state to "validated".
                 if (response)
                     response->set_cache_state(Infrastructure::Response::CacheState::Validated);
             }
@@ -2132,20 +2132,20 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             }
         }
 
-        // 11. Set response’s URL list to a clone of httpRequest’s URL list.
+        // 11. Set response's URL list to a clone of httpRequest's URL list.
         response->set_url_list(http_request->url_list());
 
-        // 12. If httpRequest’s header list contains `Range`, then set response’s range-requested flag.
+        // 12. If httpRequest's header list contains `Range`, then set response's range-requested flag.
         if (http_request->header_list()->contains("Range"sv.bytes()))
             response->set_range_requested(true);
 
-        // 13. Set response’s request-includes-credentials to includeCredentials.
+        // 13. Set response's request-includes-credentials to includeCredentials.
         response->set_request_includes_credentials(include_credentials == IncludeCredentials::Yes);
 
         auto inner_pending_response = PendingResponse::create(vm, request, *response);
 
-        // 14. If response’s status is 401, httpRequest’s response tainting is not "cors", includeCredentials is true,
-        //     and request’s traversable for user prompts is a traversable navigable:
+        // 14. If response's status is 401, httpRequest's response tainting is not "cors", includeCredentials is true,
+        //     and request's traversable for user prompts is a traversable navigable:
         if (response->status() == 401
             && http_request->response_tainting() != Infrastructure::Request::ResponseTainting::CORS
             && include_credentials == IncludeCredentials::Yes
@@ -2156,15 +2156,15 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
             // 1. Needs testing: multiple `WWW-Authenticate` headers, missing, parsing issues.
             // (Red box in the spec, no-op)
 
-            // 2. If request’s body is non-null, then:
+            // 2. If request's body is non-null, then:
             if (!request->body().has<Empty>()) {
-                // 1. If request’s body’s source is null, then return a network error.
+                // 1. If request's body's source is null, then return a network error.
                 if (request->body().get<GC::Ref<Infrastructure::Body>>()->source().has<Empty>()) {
                     returned_pending_response->resolve(Infrastructure::Response::network_error(vm, "Request has body but no body source"_string));
                     return;
                 }
 
-                // 2. Set request’s body to the body of the result of safely extracting request’s body’s source.
+                // 2. Set request's body to the body of the result of safely extracting request's body's source.
                 auto const& source = request->body().get<GC::Ref<Infrastructure::Body>>()->source();
                 // NOTE: BodyInitOrReadableBytes is a superset of Body::SourceType
                 auto converted_source = source.has<ByteBuffer>()
@@ -2174,7 +2174,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                 request->set_body(body);
             }
 
-            // 3. If request’s use-URL-credentials flag is unset or isAuthenticationFetch is true, then:
+            // 3. If request's use-URL-credentials flag is unset or isAuthenticationFetch is true, then:
             if (!request->use_url_credentials() || is_authentication_fetch == IsAuthenticationFetch::Yes) {
                 // 1. If fetchParams is canceled, then return the appropriate network error for fetchParams.
                 if (fetch_params.is_canceled()) {
@@ -2183,15 +2183,15 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                 }
 
                 // FIXME: 2. Let username and password be the result of prompting the end user for a username and password,
-                //           respectively, in request’s window.
+                //           respectively, in request's window.
                 dbgln("Fetch: Username/password prompt is not implemented, using empty strings. This request will probably fail.");
                 auto username = ByteString::empty();
                 auto password = ByteString::empty();
 
-                // 3. Set the username given request’s current URL and username.
+                // 3. Set the username given request's current URL and username.
                 request->current_url().set_username(username);
 
-                // 4. Set the password given request’s current URL and password.
+                // 4. Set the password given request's current URL and password.
                 request->current_url().set_password(password);
             }
 
@@ -2201,9 +2201,9 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
 
         inner_pending_response->when_loaded([&realm, &vm, &fetch_params, request, returned_pending_response, is_authentication_fetch, is_new_connection_fetch](GC::Ref<Infrastructure::Response> response) {
             dbgln_if(WEB_FETCH_DEBUG, "Fetch: Running 'HTTP network-or-cache fetch' inner_pending_response load callback");
-            // 15. If response’s status is 407, then:
+            // 15. If response's status is 407, then:
             if (response->status() == 407) {
-                // 1. If request’s traversable for user prompts is "no-traversable", then return a network error.
+                // 1. If request's traversable for user prompts is "no-traversable", then return a network error.
                 if (request->traversable_for_user_prompts().has<Infrastructure::Request::TraversableForUserPrompts>()
                     && request->traversable_for_user_prompts().get<Infrastructure::Request::TraversableForUserPrompts>() == Infrastructure::Request::TraversableForUserPrompts::NoTraversable) {
                     returned_pending_response->resolve(Infrastructure::Response::network_error(vm, "Request requires proxy authentication but has 'no-window' set"_string));
@@ -2219,7 +2219,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                     return;
                 }
 
-                // FIXME: 4. Prompt the end user as appropriate in request’s window and store the result as a
+                // FIXME: 4. Prompt the end user as appropriate in request's window and store the result as a
                 //           proxy-authentication entry.
                 // NOTE: Remaining details surrounding proxy authentication are defined by HTTP.
 
@@ -2231,11 +2231,11 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
 
             // 16. If all of the following are true
             if (
-                // - response’s status is 421
+                // - response's status is 421
                 response->status() == 421
                 // - isNewConnectionFetch is false
                 && is_new_connection_fetch == IsNewConnectionFetch::No
-                // - request’s body is null, or request’s body is non-null and request’s body’s source is non-null
+                // - request's body is null, or request's body is non-null and request's body's source is non-null
                 && (request->body().has<Empty>() || !request->body().get<GC::Ref<Infrastructure::Body>>()->source().has<Empty>())
                 // then:
             ) {
@@ -2262,7 +2262,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
     });
 
     // 18. Return response.
-    // NOTE: Typically response’s body’s stream is still being enqueued to after returning.
+    // NOTE: Typically response's body's stream is still being enqueued to after returning.
     return returned_pending_response;
 }
 
@@ -2364,7 +2364,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> nonstandard_resource_loader_file_o
             return promise;
         });
 
-        // 12. Let cancelAlgorithm be an algorithm that aborts fetchParams’s controller with reason, given reason.
+        // 12. Let cancelAlgorithm be an algorithm that aborts fetchParams's controller with reason, given reason.
         auto cancel_algorithm = GC::create_function(realm.heap(), [&realm, &fetch_params](JS::Value reason) {
             fetch_params.controller()->abort(realm, reason);
             return WebIDL::create_resolved_promise(realm, JS::js_undefined());
@@ -2400,26 +2400,26 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> nonstandard_resource_loader_file_o
                 response->header_list()->append(move(header));
             }
 
-            // 14. Set response’s body to a new body whose stream is stream.
+            // 14. Set response's body to a new body whose stream is stream.
             response->set_body(Infrastructure::Body::create(vm, stream));
 
             // 17. Return response.
-            // NOTE: Typically response’s body’s stream is still being enqueued to after returning.
+            // NOTE: Typically response's body's stream is still being enqueued to after returning.
             pending_response->resolve(response);
         });
 
         // 16. Run these steps in parallel:
         //    FIXME: 1. Run these steps, but abort when fetchParams is canceled:
         auto on_data_received = GC::create_function(vm.heap(), [fetched_data_receiver](ReadonlyBytes bytes) {
-            // 1. If one or more bytes have been transmitted from response’s message body, then:
+            // 1. If one or more bytes have been transmitted from response's message body, then:
             if (!bytes.is_empty()) {
                 // 1. Let bytes be the transmitted bytes.
 
-                // FIXME: 2. Let codings be the result of extracting header list values given `Content-Encoding` and response’s header list.
-                // FIXME: 3. Increase response’s body info’s encoded size by bytes’s length.
+                // FIXME: 2. Let codings be the result of extracting header list values given `Content-Encoding` and response's header list.
+                // FIXME: 3. Increase response's body info's encoded size by bytes's length.
                 // FIXME: 4. Set bytes to the result of handling content codings given codings and bytes.
-                // FIXME: 5. Increase response’s body info’s decoded size by bytes’s length.
-                // FIXME: 6. If bytes is failure, then terminate fetchParams’s controller.
+                // FIXME: 5. Increase response's body info's decoded size by bytes's length.
+                // FIXME: 6. If bytes is failure, then terminate fetchParams's controller.
 
                 // 7. Append bytes to buffer.
                 fetched_data_receiver->on_data_received(bytes);
@@ -2433,7 +2433,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> nonstandard_resource_loader_file_o
             dbgln("FIXME: Implement on_complete timing info for unbuffered requests");
             HTML::TemporaryExecutionContext execution_context { realm, HTML::TemporaryExecutionContext::CallbacksEnabled::Yes };
 
-            // 16.1.1.2. Otherwise, if the bytes transmission for response’s message body is done normally and stream is readable,
+            // 16.1.1.2. Otherwise, if the bytes transmission for response's message body is done normally and stream is readable,
             //           then close stream, and abort these in-parallel steps.
             if (success) {
                 if (stream->is_readable())
@@ -2524,9 +2524,9 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> cors_preflight_fetch(JS::Realm& re
 
     auto& vm = realm.vm();
 
-    // 1. Let preflight be a new request whose method is `OPTIONS`, URL list is a clone of request’s URL list, initiator is
-    //    request’s initiator, destination is request’s destination, origin is request’s origin, referrer is request’s referrer,
-    //    referrer policy is request’s referrer policy, mode is "cors", and response tainting is "cors".
+    // 1. Let preflight be a new request whose method is `OPTIONS`, URL list is a clone of request's URL list, initiator is
+    //    request's initiator, destination is request's destination, origin is request's origin, referrer is request's referrer,
+    //    referrer policy is request's referrer policy, mode is "cors", and response tainting is "cors".
     auto preflight = Fetch::Infrastructure::Request::create(vm);
     preflight->set_method(TRY_OR_THROW_OOM(vm, ByteBuffer::copy("OPTIONS"sv.bytes())));
     preflight->set_url_list(request.url_list());
@@ -2538,15 +2538,15 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> cors_preflight_fetch(JS::Realm& re
     preflight->set_mode(Infrastructure::Request::Mode::CORS);
     preflight->set_response_tainting(Infrastructure::Request::ResponseTainting::CORS);
 
-    // 2. Append (`Accept`, `*/*`) to preflight’s header list.
+    // 2. Append (`Accept`, `*/*`) to preflight's header list.
     auto temp_header = Infrastructure::Header::from_string_pair("Accept"sv, "*/*"sv);
     preflight->header_list()->append(move(temp_header));
 
-    // 3. Append (`Access-Control-Request-Method`, request’s method) to preflight’s header list.
+    // 3. Append (`Access-Control-Request-Method`, request's method) to preflight's header list.
     temp_header = Infrastructure::Header::from_string_pair("Access-Control-Request-Method"sv, request.method());
     preflight->header_list()->append(move(temp_header));
 
-    // 4. Let headers be the CORS-unsafe request-header names with request’s header list.
+    // 4. Let headers be the CORS-unsafe request-header names with request's header list.
     auto headers = Infrastructure::get_cors_unsafe_header_names(request.header_list());
 
     // 5. If headers is not empty, then:
@@ -2564,7 +2564,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> cors_preflight_fetch(JS::Realm& re
             first = false;
         }
 
-        // 2. Append (`Access-Control-Request-Headers`, value) to preflight’s header list.
+        // 2. Append (`Access-Control-Request-Headers`, value) to preflight's header list.
         temp_header = Infrastructure::Header {
             .name = TRY_OR_THROW_OOM(vm, ByteBuffer::copy("Access-Control-Request-Headers"sv.bytes())),
             .value = move(value),
@@ -2584,14 +2584,14 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> cors_preflight_fetch(JS::Realm& re
     preflight_response->when_loaded([&vm, &request, returned_pending_response](GC::Ref<Infrastructure::Response> response) {
         dbgln_if(WEB_FETCH_DEBUG, "Fetch: Running 'CORS-preflight fetch' preflight_response load callback");
 
-        // 7. If a CORS check for request and response returns success and response’s status is an ok status, then:
+        // 7. If a CORS check for request and response returns success and response's status is an ok status, then:
         // NOTE: The CORS check is done on request rather than preflight to ensure the correct credentials mode is used.
         if (cors_check(request, response) && Infrastructure::is_ok_status(response->status())) {
-            // 1. Let methods be the result of extracting header list values given `Access-Control-Allow-Methods` and response’s header list.
+            // 1. Let methods be the result of extracting header list values given `Access-Control-Allow-Methods` and response's header list.
             auto methods_or_failure = Infrastructure::extract_header_list_values("Access-Control-Allow-Methods"sv.bytes(), response->header_list());
 
             // 2. Let headerNames be the result of extracting header list values given `Access-Control-Allow-Headers` and
-            //    response’s header list.
+            //    response's header list.
             auto header_names_or_failure = Infrastructure::extract_header_list_values("Access-Control-Allow-Headers"sv.bytes(), response->header_list());
 
             // 3. If either methods or headerNames is failure, return a network error.
@@ -2611,12 +2611,12 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> cors_preflight_fetch(JS::Realm& re
             // NOTE: We treat "header_names_or_failure" being `Empty` as empty Vector here.
             auto header_names = header_names_or_failure.has<Vector<ByteBuffer>>() ? header_names_or_failure.get<Vector<ByteBuffer>>() : Vector<ByteBuffer> {};
 
-            // 4. If methods is null and request’s use-CORS-preflight flag is set, then set methods to a new list containing request’s method.
-            // NOTE: This ensures that a CORS-preflight fetch that happened due to request’s use-CORS-preflight flag being set is cached.
+            // 4. If methods is null and request's use-CORS-preflight flag is set, then set methods to a new list containing request's method.
+            // NOTE: This ensures that a CORS-preflight fetch that happened due to request's use-CORS-preflight flag being set is cached.
             if (methods.is_empty() && request.use_cors_preflight())
                 methods = Vector { TRY_OR_IGNORE(ByteBuffer::copy(request.method())) };
 
-            // 5. If request’s method is not in methods, request’s method is not a CORS-safelisted method, and request’s credentials mode
+            // 5. If request's method is not in methods, request's method is not a CORS-safelisted method, and request's credentials mode
             //    is "include" or methods does not contain `*`, then return a network error.
             if (!methods.contains_slow(request.method()) && !Infrastructure::is_cors_safelisted_method(request.method())) {
                 if (request.credentials_mode() == Infrastructure::Request::CredentialsMode::Include) {
@@ -2630,7 +2630,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> cors_preflight_fetch(JS::Realm& re
                 }
             }
 
-            // 6. If one of request’s header list’s names is a CORS non-wildcard request-header name and is not a byte-case-insensitive match
+            // 6. If one of request's header list's names is a CORS non-wildcard request-header name and is not a byte-case-insensitive match
             //    for an item in headerNames, then return a network error.
             for (auto const& header : *request.header_list()) {
                 if (Infrastructure::is_cors_non_wildcard_request_header_name(header.name)) {
@@ -2650,8 +2650,8 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> cors_preflight_fetch(JS::Realm& re
                 }
             }
 
-            // 7. For each unsafeName of the CORS-unsafe request-header names with request’s header list, if unsafeName is not a
-            //    byte-case-insensitive match for an item in headerNames and request’s credentials mode is "include" or headerNames
+            // 7. For each unsafeName of the CORS-unsafe request-header names with request's header list, if unsafeName is not a
+            //    byte-case-insensitive match for an item in headerNames and request's credentials mode is "include" or headerNames
             //    does not contain `*`, return a network error.
             auto unsafe_names = Infrastructure::get_cors_unsafe_header_names(request.header_list());
             for (auto const& unsafe_name : unsafe_names) {
@@ -2677,7 +2677,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> cors_preflight_fetch(JS::Realm& re
                 }
             }
 
-            // FIXME: 8. Let max-age be the result of extracting header list values given `Access-Control-Max-Age` and response’s header list.
+            // FIXME: 8. Let max-age be the result of extracting header list values given `Access-Control-Max-Age` and response's header list.
             // FIXME: 9. If max-age is failure or null, then set max-age to 5.
             // FIXME: 10. If max-age is greater than an imposed limit on max-age, then set max-age to the imposed limit.
 
@@ -2686,12 +2686,12 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> cors_preflight_fetch(JS::Realm& re
             returned_pending_response->resolve(response);
             return;
 
-            // FIXME: 12. For each method in methods for which there is a method cache entry match using request, set matching entry’s max-age
+            // FIXME: 12. For each method in methods for which there is a method cache entry match using request, set matching entry's max-age
             //            to max-age.
             // FIXME: 13. For each method in methods for which there is no method cache entry match using request, create a new cache entry
             //            with request, max-age, method, and null.
             // FIXME: 14. For each headerName in headerNames for which there is a header-name cache entry match using request, set matching
-            //            entry’s max-age to max-age.
+            //            entry's max-age to max-age.
             // FIXME: 15. For each headerName in headerNames for which there is no header-name cache entry match using request, create a
             //            new cache entry with request, max-age, null, and headerName.
             // FIXME: 16. Return response.
@@ -2707,13 +2707,13 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> cors_preflight_fetch(JS::Realm& re
 // https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-set-dest
 void set_sec_fetch_dest_header(Infrastructure::Request& request)
 {
-    // 1. Assert: r’s url is a potentially trustworthy URL.
+    // 1. Assert: r's url is a potentially trustworthy URL.
     VERIFY(SecureContexts::is_url_potentially_trustworthy(request.url()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy);
 
     // 2. Let header be a Structured Header whose value is a token.
     // FIXME: This is handled below, as Serenity doesn't have APIs for RFC 8941.
 
-    // 3. If r’s destination is the empty string, set header’s value to the string "empty". Otherwise, set header’s value to r’s destination.
+    // 3. If r's destination is the empty string, set header's value to the string "empty". Otherwise, set header's value to r's destination.
     ByteBuffer header_value;
     if (!request.destination().has_value()) {
         header_value = MUST(ByteBuffer::copy("empty"sv.bytes()));
@@ -2721,7 +2721,7 @@ void set_sec_fetch_dest_header(Infrastructure::Request& request)
         header_value = MUST(ByteBuffer::copy(Infrastructure::request_destination_to_string(request.destination().value()).bytes()));
     }
 
-    // 4. Set a structured field value `Sec-Fetch-Dest`/header in r’s header list.
+    // 4. Set a structured field value `Sec-Fetch-Dest`/header in r's header list.
     auto header = Infrastructure::Header {
         .name = MUST(ByteBuffer::copy("Sec-Fetch-Dest"sv.bytes())),
         .value = move(header_value),
@@ -2732,16 +2732,16 @@ void set_sec_fetch_dest_header(Infrastructure::Request& request)
 // https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-set-dest
 void set_sec_fetch_mode_header(Infrastructure::Request& request)
 {
-    // 1. Assert: r’s url is a potentially trustworthy URL.
+    // 1. Assert: r's url is a potentially trustworthy URL.
     VERIFY(SecureContexts::is_url_potentially_trustworthy(request.url()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy);
 
     // 2. Let header be a Structured Header whose value is a token.
     // FIXME: This is handled below, as Serenity doesn't have APIs for RFC 8941.
 
-    // 3. Set header’s value to r’s mode.
+    // 3. Set header's value to r's mode.
     auto header_value = MUST(ByteBuffer::copy(Infrastructure::request_mode_to_string(request.mode()).bytes()));
 
-    // 4. Set a structured field value `Sec-Fetch-Mode`/header in r’s header list.
+    // 4. Set a structured field value `Sec-Fetch-Mode`/header in r's header list.
     auto header = Infrastructure::Header {
         .name = MUST(ByteBuffer::copy("Sec-Fetch-Mode"sv.bytes())),
         .value = move(header_value),
@@ -2752,41 +2752,41 @@ void set_sec_fetch_mode_header(Infrastructure::Request& request)
 // https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-set-site
 void set_sec_fetch_site_header(Infrastructure::Request& request)
 {
-    // 1. Assert: r’s url is a potentially trustworthy URL.
+    // 1. Assert: r's url is a potentially trustworthy URL.
     VERIFY(SecureContexts::is_url_potentially_trustworthy(request.url()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy);
 
     // 2. Let header be a Structured Header whose value is a token.
     // FIXME: This is handled below, as Serenity doesn't have APIs for RFC 8941.
 
-    // 3. Set header’s value to same-origin.
+    // 3. Set header's value to same-origin.
     auto header_value = "same-origin"sv;
 
-    // FIXME: 4. If r is a navigation request that was explicitly caused by a user’s interaction with the user agent (by typing an address
-    //           into the user agent directly, for example, or by clicking a bookmark, etc.), then set header’s value to none.
+    // FIXME: 4. If r is a navigation request that was explicitly caused by a user's interaction with the user agent (by typing an address
+    //           into the user agent directly, for example, or by clicking a bookmark, etc.), then set header's value to none.
 
-    // 5. If header’s value is not none, then for each url in r’s url list:
+    // 5. If header's value is not none, then for each url in r's url list:
     if (!header_value.equals_ignoring_ascii_case("none"sv)) {
         VERIFY(request.origin().has<URL::Origin>());
         auto& request_origin = request.origin().get<URL::Origin>();
 
         for (auto& url : request.url_list()) {
-            // 1. If url is same origin with r’s origin, continue.
+            // 1. If url is same origin with r's origin, continue.
             if (url.origin().is_same_origin(request_origin))
                 continue;
 
-            // 2. Set header’s value to cross-site.
+            // 2. Set header's value to cross-site.
             header_value = "cross-site"sv;
 
-            // 3. If r’s origin is not same site with url’s origin, then break.
+            // 3. If r's origin is not same site with url's origin, then break.
             if (!request_origin.is_same_site(url.origin()))
                 break;
 
-            // 4. Set header’s value to same-site.
+            // 4. Set header's value to same-site.
             header_value = "same-site"sv;
         }
     }
 
-    // 6. Set a structured field value `Sec-Fetch-Site`/header in r’s header list.
+    // 6. Set a structured field value `Sec-Fetch-Site`/header in r's header list.
     auto header = Infrastructure::Header {
         .name = MUST(ByteBuffer::copy("Sec-Fetch-Site"sv.bytes())),
         .value = MUST(ByteBuffer::copy(header_value.bytes())),
@@ -2797,21 +2797,21 @@ void set_sec_fetch_site_header(Infrastructure::Request& request)
 // https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-set-user
 void set_sec_fetch_user_header(Infrastructure::Request& request)
 {
-    // 1. Assert: r’s url is a potentially trustworthy URL.
+    // 1. Assert: r's url is a potentially trustworthy URL.
     VERIFY(SecureContexts::is_url_potentially_trustworthy(request.url()) == SecureContexts::Trustworthiness::PotentiallyTrustworthy);
 
-    // 2. If r is not a navigation request, or if r’s user-activation is false, return.
+    // 2. If r is not a navigation request, or if r's user-activation is false, return.
     if (!request.is_navigation_request() || !request.user_activation())
         return;
 
     // 3. Let header be a Structured Header whose value is a token.
     // FIXME: This is handled below, as Serenity doesn't have APIs for RFC 8941.
 
-    // 4. Set header’s value to true.
+    // 4. Set header's value to true.
     // NOTE: See https://datatracker.ietf.org/doc/html/rfc8941#name-booleans for boolean format in RFC 8941.
     auto header_value = MUST(ByteBuffer::copy("?1"sv.bytes()));
 
-    // 5. Set a structured field value `Sec-Fetch-User`/header in r’s header list.
+    // 5. Set a structured field value `Sec-Fetch-User`/header in r's header list.
     auto header = Infrastructure::Header {
         .name = MUST(ByteBuffer::copy("Sec-Fetch-User"sv.bytes())),
         .value = move(header_value),
@@ -2822,7 +2822,7 @@ void set_sec_fetch_user_header(Infrastructure::Request& request)
 // https://w3c.github.io/webappsec-fetch-metadata/#abstract-opdef-append-the-fetch-metadata-headers-for-a-request
 void append_fetch_metadata_headers_for_request(Infrastructure::Request& request)
 {
-    // 1. If r’s url is not an potentially trustworthy URL, return.
+    // 1. If r's url is not an potentially trustworthy URL, return.
     if (SecureContexts::is_url_potentially_trustworthy(request.url()) != SecureContexts::Trustworthiness::PotentiallyTrustworthy)
         return;
 

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1974,9 +1974,9 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                     auto const& url = http_request->current_url();
                     auto payload = MUST(String::formatted("{}:{}", URL::percent_decode(url.username()), URL::percent_decode(url.password())));
                     auto token = TRY_OR_THROW_OOM(vm, encode_base64(payload.bytes()));
-                    dbgln_if(Web::Fetch::Infrastructure::debug_fetch, "Fetch: Constructing Basic Authorization header from URL credentials (username present: {}, password present: {})",
+                    dbgln_if(WEB_FETCH_DEBUG, "Fetch: Constructing Basic Authorization header from URL credentials (username present: {}, password present: {})",
                         !url.username().is_empty(), !url.password().is_empty());
-                    authorization_value = String::formatted("Basic {}", token);
+                    authorization_value = TRY_OR_THROW_OOM(vm, String::formatted("Basic {}", token));
                 }
 
                 // 4. If authorizationValue is non-null, then append (`Authorization`, authorizationValue) to

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1974,8 +1974,7 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                     auto const& url = http_request->current_url();
                     auto payload = MUST(String::formatted("{}:{}", URL::percent_decode(url.username()), URL::percent_decode(url.password())));
                     auto token = TRY_OR_THROW_OOM(vm, encode_base64(payload.bytes()));
-                    dbgln_if(WEB_FETCH_DEBUG, "Fetch: Constructing Basic Authorization header from URL credentials (username present: {}, password present: {})",
-                        !url.username().is_empty(), !url.password().is_empty());
+                    dbgln_if(WEB_FETCH_DEBUG, "Fetch: Constructing Basic Authorization header from URL credentials (username present: {}, password present: {})", !url.username().is_empty(), !url.password().is_empty());
                     authorization_value = TRY_OR_THROW_OOM(vm, String::formatted("Basic {}", token));
                 }
 

--- a/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
+++ b/Libraries/LibWeb/Fetch/Fetching/Fetching.cpp
@@ -1973,7 +1973,10 @@ WebIDL::ExceptionOr<GC::Ref<PendingResponse>> http_network_or_cache_fetch(JS::Re
                 else if (http_request->current_url().includes_credentials() && is_authentication_fetch == IsAuthenticationFetch::Yes) {
                     auto const& url = http_request->current_url();
                     auto payload = MUST(String::formatted("{}:{}", URL::percent_decode(url.username()), URL::percent_decode(url.password())));
-                    authorization_value = TRY_OR_THROW_OOM(vm, encode_base64(payload.bytes()));
+                    auto token = TRY_OR_THROW_OOM(vm, encode_base64(payload.bytes()));
+                    dbgln_if(Web::Fetch::Infrastructure::debug_fetch, "Fetch: Constructing Basic Authorization header from URL credentials (username present: {}, password present: {})",
+                        !url.username().is_empty(), !url.password().is_empty());
+                    authorization_value = String::formatted("Basic {}", token);
                 }
 
                 // 4. If authorizationValue is non-null, then append (`Authorization`, authorizationValue) to


### PR DESCRIPTION
Prefix Authorization header with 'Basic ' for URL-embedded credentials to align with Fetch spec.

---
<a href="https://cursor.com/background-agent?bcId=bc-df673fea-fbe6-4aa2-bde6-7bda18cb5aec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df673fea-fbe6-4aa2-bde6-7bda18cb5aec">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

